### PR TITLE
PLG-104: Exclude category/customer/product sync if module is disabled

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -219,12 +219,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             if ($storeId == 0) { // store 0 is always admin
                 continue;
             }
-            $storeIdConfigMap[$storeId] = $this->scopeConfig
-                ->getValue(
-                    'metrilo_analytics/general/api_key',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    $storeId
-                );
+            
+            if ($this->isEnabled($storeId)) {
+                $storeIdConfigMap[$storeId] = $this->scopeConfig
+                    ->getValue(
+                        'metrilo_analytics/general/api_key',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        $storeId
+                    );
+            }
         }
         $storeIdConfigMap = array_unique($storeIdConfigMap);
         

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -216,18 +216,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getStoreIdsPerProject($storeIds) {
         $storeIdConfigMap = [];
         foreach ($storeIds as $storeId) {
-            if ($storeId == 0) { // store 0 is always admin
+            if ($storeId == 0 || !$this->isEnabled($storeId)) { // store 0 is always admin
                 continue;
             }
             
-            if ($this->isEnabled($storeId)) {
-                $storeIdConfigMap[$storeId] = $this->scopeConfig
-                    ->getValue(
-                        'metrilo_analytics/general/api_key',
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                        $storeId
-                    );
-            }
+            $storeIdConfigMap[$storeId] = $this->scopeConfig
+                ->getValue(
+                    'metrilo_analytics/general/api_key',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                    $storeId
+                );
         }
         $storeIdConfigMap = array_unique($storeIdConfigMap);
         

--- a/Observer/Category.php
+++ b/Observer/Category.php
@@ -8,11 +8,10 @@ use Magento\Framework\Event\ObserverInterface;
 class Category implements ObserverInterface
 {
     /**
-     * @param \Metrilo\Analytics\Helper\Data                                  $helper
-     * @param \Metrilo\Analytics\Helper\ApiClient                             $apiClient
-     * @param \Metrilo\Analytics\Helper\CategorySerializer                    $categorySerializer
-     * @param \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory $categoryCollection
-     * @param \Magento\Store\Model\StoreManagerInterface                      $storeManager
+     * @param \Metrilo\Analytics\Helper\Data               $helper
+     * @param \Metrilo\Analytics\Helper\ApiClient          $apiClient
+     * @param \Metrilo\Analytics\Helper\CategorySerializer $categorySerializer
+     * @param \Metrilo\Analytics\Model\CategoryData        $categoryData
      */
     public function __construct(
         \Metrilo\Analytics\Helper\Data               $helper,
@@ -29,12 +28,18 @@ class Category implements ObserverInterface
     public function execute(Observer $observer)
     {
         try {
-            $category = $observer->getEvent()->getCategory();
-            if ($category->getStoreId() == 0) {
-                $categoryStoreIds = $this->helper->getStoreIdsPerProject($category->getStoreIds());
+            $category        = $observer->getEvent()->getCategory();
+            $categoryStoreId = $category->getStoreId();
+            
+            if ($categoryStoreId == 0) {
+                $categoryStoreIds   = $this->helper->getStoreIdsPerProject($category->getStoreIds());
             } else {
-                $categoryStoreIds[] = $category->getStoreId();
+                if (!$this->helper->isEnabled($categoryStoreId)) {
+                    return;
+                }
+                $categoryStoreIds[] = $categoryStoreId;
             }
+            
             foreach ($categoryStoreIds as $storeId) {
                 $categoryObject = $this->categoryData->getCategoryWithRequestPath($category->getId(), $storeId);
                 $client         = $this->apiClient->getClient($storeId);

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -71,6 +71,10 @@ class Customer implements ObserverInterface
             $customer = $this->getCustomerFromEvent($observer);
             
             if ($customer) {
+                if (!$this->helper->isEnabled($customer->getStoreId())) {
+                    return;
+                }
+                
                 if (!trim($customer->getEmail())) {
                     $this->helper->logError('Customer with id = '. $customer->getId(). '  has no email address!');
                     return;

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -70,11 +70,7 @@ class Customer implements ObserverInterface
         try {
             $customer = $this->getCustomerFromEvent($observer);
             
-            if ($customer) {
-                if (!$this->helper->isEnabled($customer->getStoreId())) {
-                    return;
-                }
-                
+            if ($customer && $this->helper->isEnabled($customer->getStoreId())) {
                 if (!trim($customer->getEmail())) {
                     $this->helper->logError('Customer with id = '. $customer->getId(). '  has no email address!');
                     return;

--- a/Observer/Product.php
+++ b/Observer/Product.php
@@ -34,9 +34,12 @@ class Product implements ObserverInterface
             if ($productStoreId == 0) {
                 $productStoreIds   = $this->helper->getStoreIdsPerProject($product->getStoreIds());
             } else {
+                if (!$this->helper->isEnabled($productStoreId)) {
+                    return;
+                }
                 $productStoreIds[] = $productStoreId;
             }
-    
+            
             foreach ($productStoreIds as $storeId) {
                 $client         = $this->apiClient->getClient($storeId);
                 $productParents = $this->productSerializer->productOptions->getParentIds($product->getId());


### PR DESCRIPTION
Additional module status checks were placed for category/customer/product observers in order to exclude sync if module status is disabled for the current project.