### PR TITLE
PLG-118: Avoid errors when registry object for product/category is missing.

### DIFF
--- a/Model/Analytics.php
+++ b/Model/Analytics.php
@@ -69,7 +69,10 @@ class Analytics extends DataObject
         // category view pages
         if ($this->fullActionName == 'catalog_category_view') {
             $category = $this->_coreRegistry->registry('current_category');
-
+            if (!isset($category)) {
+                return;
+            }
+            
             $data =  [
                 'id'    =>  $category->getId(),
                 'name'  =>  $category->getName()
@@ -83,6 +86,10 @@ class Analytics extends DataObject
         if ($this->fullActionName == 'catalog_product_view') {
             /** @var \Magento\Catalog\Model\Product $product */
             $product = $this->_coreRegistry->registry('current_product');
+            if (!isset($product)) {
+                return;
+            }
+            
             $data =  [
                 'id'    => $product->getId(),
                 'sku'   => $product->getSku(),


### PR DESCRIPTION
This fix is required to avoid errors when 3d party modules are forcing page reloads with missing product/category data from the magento global registry object.