### PR TITLE
KYP-546: Limit plugin error log size.

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -71,9 +71,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function log($value)
     {
         $logLocation = BP . '/var/log/metrilo.log';
-        // 2mb in bytes = 2097152
-        // 100mb in bytes = 104857600
-        if (file_exists($logLocation) && filesize($logLocation) > 2000000) {
+        if (file_exists($logLocation) && filesize($logLocation) > 104857600) {
             unlink($logLocation);
         }
         

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -70,10 +70,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function log($value)
     {
-        $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/metrilo.log');
+        $logLocation = BP . '/var/log/metrilo.log';
+        // 2mb in bytes = 2097152
+        // 100mb in bytes = 104857600
+        if (file_exists($logLocation) && filesize($logLocation) > 2000000) {
+            unlink($logLocation);
+        }
+        
+        $writer = new \Zend\Log\Writer\Stream($logLocation);
         $logger = new \Zend\Log\Logger();
         $logger->addWriter($writer);
-
+        
         $logger->err($value);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -10,11 +10,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
-        \Psr\Log\LoggerInterface                           $logger,
         \Magento\Store\Model\StoreManagerInterface         $storeManager
     ) {
         $this->config       = $config;
-        $this->logger       = $logger;
         $this->storeManager = $storeManager;
     }
 
@@ -71,7 +69,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function log($value)
     {
         $logLocation = BP . '/var/log/metrilo.log';
-        if (file_exists($logLocation) && filesize($logLocation) > 104857600) {
+        if (file_exists($logLocation) && filesize($logLocation) > 10 * 1024 * 1024) {
             unlink($logLocation);
         }
         


### PR DESCRIPTION
Delete the metrilo.log file if it's size exceeds 100mb.