### PR TITLE
KYP-626: Handle phone orders in magento plugin

### DIFF
--- a/Helper/OrderSerializer.php
+++ b/Helper/OrderSerializer.php
@@ -38,10 +38,10 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
         ];
         
         if (empty($order->getCustomerEmail())) {
-            if (isset($orderPhone)) {
-                $customerEmail = $orderPhone . '@phone_email';
-            } else {
+            if (empty($orderPhone)) {
                 return false;
+            } else {
+                $customerEmail = $orderPhone . '@phone_email';
             }
         } else {
             $customerEmail = $order->getCustomerEmail();

--- a/Helper/OrderSerializer.php
+++ b/Helper/OrderSerializer.php
@@ -37,16 +37,13 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             "paymentMethod" => $order->getPayment()->getMethodInstance()->getTitle()
         ];
         
-        if (empty($order->getCustomerEmail())) {
-            if (empty($orderPhone)) {
-                return false;
-            } else {
-                $customerEmail = $orderPhone . '@phone_email';
-            }
-        } else {
+        if (!empty($order->getCustomerEmail())) {
             $customerEmail = $order->getCustomerEmail();
+        } elseif (!empty($orderPhone)) {
+            $customerEmail = $orderPhone . '@phone_email';
+        } else {
+            return false;
         }
-        
         
         $serializedOrder = [
             'id'        => $order->getIncrementId(),

--- a/Helper/OrderSerializer.php
+++ b/Helper/OrderSerializer.php
@@ -22,6 +22,7 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
         }
     
         $orderBillingData = $order->getBillingAddress();
+        $orderPhone       = $orderBillingData->getTelephone();
         $street           = $orderBillingData->getStreet();
         $couponCode       = $order->getCouponCode() ? [$order->getCouponCode()] : [];
     
@@ -31,15 +32,26 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             "address"       => is_array($street) ? implode(PHP_EOL, $street) : $street,
             "city"          => $orderBillingData->getCity(),
             "countryCode"   => $orderBillingData->getCountryId(),
-            "phone"         => $orderBillingData->getTelephone(),
+            "phone"         => $orderPhone,
             "postcode"      => $orderBillingData->getPostcode(),
             "paymentMethod" => $order->getPayment()->getMethodInstance()->getTitle()
         ];
-    
+        
+        if (empty($order->getCustomerEmail())) {
+            if (isset($orderPhone)) {
+                $customerEmail = $orderPhone . '@phone_email';
+            } else {
+                return false;
+            }
+        } else {
+            $customerEmail = $order->getCustomerEmail();
+        }
+        
+        
         $serializedOrder = [
             'id'        => $order->getIncrementId(),
             'createdAt' => strtotime($order->getCreatedAt()) * 1000,
-            'email'     => $order->getCustomerEmail(),
+            'email'     => $customerEmail,
             'amount'    => $order->getBaseGrandTotal() - $order->getTotalRefunded(),
             'coupons'   => $couponCode,
             'status'    => $order->getStatus(),

--- a/Model/OrderData.php
+++ b/Model/OrderData.php
@@ -22,7 +22,6 @@ class OrderData
         
         return $this->orderCollection->create()
             ->addAttributeToFilter('store_id', $storeId)
-            ->addAttributeToFilter('customer_email', array('neq' => '')) //only return orders with email
             ->addAttributeToSelect('*')
             ->setOrder('entity_id', 'asc');
     }

--- a/Observer/Order.php
+++ b/Observer/Order.php
@@ -39,14 +39,12 @@ class Order implements ObserverInterface
                 return;
             }
             
-            if (!trim($order->getCustomerEmail())) {
-                return;
-            }
-            
             $client          = $this->apiClient->getClient($storeId);
             $serializedOrder = $this->orderSerializer->serialize($order);
             
-            $client->order($serializedOrder);
+            if ($serializedOrder) {
+                $client->order($serializedOrder);
+            }
         } catch (\Exception $e) {
             $this->helper->logError($e);
         }


### PR DESCRIPTION
Add phone email for customers with missing email. Discard sync if no email and phone number are present.