### PR TITLE
KYP-1184: Reworked parent child relation use of id instead of sku

### DIFF
--- a/Api/Connection.php
+++ b/Api/Connection.php
@@ -59,9 +59,9 @@ class Connection
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return array(
+        return [
             'response' => $response,
             'code' => $code
-        );
+        ];
     }
 }

--- a/Helper/DeletedProductSerializer.php
+++ b/Helper/DeletedProductSerializer.php
@@ -26,7 +26,7 @@ class DeletedProductSerializer extends \Magento\Framework\App\Helper\AbstractHel
                     
                     if ($parentProduct) {
                         $productOptions[] = [
-                            'id'       => $itemSku ? $itemSku : $itemId,
+                            'id'       => $itemId,
                             'sku'      => $itemSku,
                             'name'     => $itemName,
                             'price'    => $parentProduct->getPrice(),

--- a/Helper/OrderSerializer.php
+++ b/Helper/OrderSerializer.php
@@ -15,10 +15,11 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             if ($itemType == 'configurable') { // exclude configurable parent product returned by getAllItems() method
                 continue;
             }
-    
-            $parentItem      = $orderItem->getParentItem();
-            $orderItemSku    = $parentItem ? $orderItem->getData('sku') : $orderItem->getProductId();
-            $orderProducts[] = ['productId'  => $orderItemSku, 'quantity'   => $orderItem->getQtyOrdered()];
+            
+            $orderProducts[] = [
+                'productId'  => $orderItem->getProductId(),
+                'quantity'   => (int)$orderItem->getQtyOrdered()
+            ];
         }
     
         $orderBillingData = $order->getBillingAddress();

--- a/Helper/ProductOptions.php
+++ b/Helper/ProductOptions.php
@@ -21,11 +21,10 @@ class ProductOptions extends \Magento\Framework\App\Helper\AbstractHelper
             $childImage = $childProduct->getImage();
             $imageUrl = (!empty($childImage)) ? $this->productImageUrl->getProductImageUrl($childImage) : '';
             
-            $childProductSku          = $childProduct->getSku();
             $childProductSpecialPrice = $childProduct->getSpecialPrice();
             $productOptions[] = [
-                'id'       => $childProductSku ? $childProductSku : $childProduct->getId(),
-                'sku'      => $childProductSku,
+                'id'       => $childProduct->getId(),
+                'sku'      => $childProduct->getSku(),
                 'name'     => $childProduct->getName(),
                 'price'    => $childProductSpecialPrice ? $childProductSpecialPrice : $childProduct->getPrice(),
                 'imageUrl' => $imageUrl

--- a/Model/CategoryData.php
+++ b/Model/CategoryData.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Model;
 
 class CategoryData
 {
-    public $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
     
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory $categoryCollection

--- a/Model/CustomerData.php
+++ b/Model/CustomerData.php
@@ -10,7 +10,7 @@ class CustomerData
     private $subscriberModel;
     private $groupRepository;
     
-    public $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
 
     public function __construct(
         \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory $customerCollection,

--- a/Model/Events/AddToCart.php
+++ b/Model/Events/AddToCart.php
@@ -11,26 +11,10 @@ class AddToCart
     }
     public function callJS()
     {
-        return "window.metrilo.addToCart('" .
-            $this->getItemIdentifier() . "', " .
-            $this->event->getQuoteItem()->getData('qty_to_add') . ");";
-    }
-    
-    private function getItemIdentifier()
-    {
         $item = $this->event->getQuoteItem();
-        $itemOptions = $item->getChildren();
         
-        if ($itemOptions) {
-            $itemSku = $itemOptions[0]->getSku();
-            
-            if ($itemSku) {
-                return $itemSku;
-            } else {
-                return $itemOptions[0]->getProductId();
-            }
-        }
-        
-        return $item->getProductId();
+        return "window.metrilo.addToCart('" .
+            $item->getProductId() . "', " .
+            (int)$item->getData('qty_to_add') . ");";
     }
 }

--- a/Model/Events/RemoveFromCart.php
+++ b/Model/Events/RemoveFromCart.php
@@ -11,26 +11,10 @@ class RemoveFromCart
     }
     public function callJS()
     {
-        return "window.metrilo.removeFromCart('" .
-            $this->getItemIdentifier() . "', " .
-            $this->event->getQuoteItem()->getQty() . ");";
-    }
-    
-    private function getItemIdentifier()
-    {
         $item = $this->event->getQuoteItem();
-        $itemOptions = $item->getChildren();
-    
-        if ($itemOptions) {
-            $itemSku = $itemOptions[0]->getSku();
         
-            if ($itemSku) {
-                return $itemSku;
-            } else {
-                return $itemOptions[0]->getProductId();
-            }
-        }
-    
-        return $item->getProductId();
+        return "window.metrilo.removeFromCart('" .
+            $item->getProductId() . "', " .
+            (int)$item->getQty() . ");";
     }
 }

--- a/Model/OrderData.php
+++ b/Model/OrderData.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Model;
 
 class OrderData
 {
-    public $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
 
     public function __construct(
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollection

--- a/Model/ProductData.php
+++ b/Model/ProductData.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Model;
 
 class ProductData
 {
-    public $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
 
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollection
@@ -66,7 +66,6 @@ class ProductData
                 'request_path',
                 'visibility'
             ])
-            ->addAttributeToFilter('visibility', \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
             ->addStoreFilter($storeId);
     }
 }

--- a/Test/Unit/Helper/ProductOptionsTest.php
+++ b/Test/Unit/Helper/ProductOptionsTest.php
@@ -39,6 +39,7 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
         $this->productCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(array_merge(get_class_methods(Collection::class), [
+                'getId',
                 'getTypeId',
                 'getTypeInstance',
                 'getUsedProducts',
@@ -65,6 +66,8 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnSelf());
         $this->productCollection->expects($this->any())->method('getUsedProducts')
             ->will($this->returnValue([$this->productCollection]));
+        $this->productCollection->expects($this->any())->method('getId')
+            ->will($this->returnValue((int)'1'));
         $this->productCollection->expects($this->any())->method('getImage')
             ->will($this->returnValue($imageUrl));
         $this->productCollection->expects($this->any())->method('getSku')
@@ -81,7 +84,7 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('base/url/string/' . 'catalog/product' . $imageUrl));
         
         $expected[] = [
-                'id'       => 'productSku',
+                'id'       => 1,
                 'sku'      => 'productSku',
                 'name'     => 'productName',
                 'price'    => 'productSpecialPrice',

--- a/Test/Unit/Model/Events/AddToCartTest.php
+++ b/Test/Unit/Model/Events/AddToCartTest.php
@@ -23,7 +23,6 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
      */
     private $addToCartEvent;
     
-    private $productSku            = 'productSku';
     private $simpleProductId       = 333;
     private $configurableProductId = 444;
     private $productQuantity       = 3;
@@ -38,7 +37,7 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
     
         $this->quoteItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getChildren', 'getProductId', 'getData', 'getSku'])
+            ->setMethods(['getProductId', 'getData'])
             ->getMock();
         
         $this->event->expects($this->any())->method('getQuoteItem')
@@ -49,8 +48,6 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
     
     public function testCallJsWithSimpleProduct()
     {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([]));
         $this->quoteItem->expects($this->any())->method('getProductId')
             ->will($this->returnValue($this->simpleProductId));
         $this->quoteItem->expects($this->any())->method('getData')
@@ -64,37 +61,14 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
     
-    public function testCallJsWithConfigurableProductWithSku()
+    public function testCallJsWithConfigurableProduct()
     {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([$this->quoteItem]));
-        $this->quoteItem->expects($this->any())->method('getSku')
-            ->will($this->returnValue($this->productSku));
         $this->quoteItem->expects($this->any())->method('getProductId')
             ->will($this->returnValue($this->configurableProductId));
         $this->quoteItem->expects($this->any())->method('getData')
             ->with($this->equalTo($this->getDataParam))
             ->will($this->returnValue($this->productQuantity));
     
-        $expected = "window.metrilo.addToCart('" . $this->productSku . "', " . $this->productQuantity . ");";
-        
-        $result = $this->addToCartEvent->callJS();
-        
-        $this->assertSame($expected, $result);
-    }
-    
-    public function testCallJsWithConfigurableProductWithoutSku()
-    {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([$this->quoteItem]));
-        $this->quoteItem->expects($this->any())->method('getSku')
-            ->will($this->returnValue(''));
-        $this->quoteItem->expects($this->any())->method('getProductId')
-            ->will($this->returnValue($this->configurableProductId));
-        $this->quoteItem->expects($this->any())->method('getData')
-            ->with($this->equalTo($this->getDataParam))
-            ->will($this->returnValue($this->productQuantity));
-        
         $expected = "window.metrilo.addToCart('" . $this->configurableProductId . "', " . $this->productQuantity . ");";
         
         $result = $this->addToCartEvent->callJS();

--- a/Test/Unit/Model/Events/RemoveFromCartTest.php
+++ b/Test/Unit/Model/Events/RemoveFromCartTest.php
@@ -23,7 +23,6 @@ class RemoveFromCartTest extends \PHPUnit\Framework\TestCase
      */
     private $removeFromCartEvent;
     
-    private $productSku            = 'productSku';
     private $simpleProductId       = 123;
     private $configurableProductId = 321;
     private $productQuantity       = 2;
@@ -37,7 +36,7 @@ class RemoveFromCartTest extends \PHPUnit\Framework\TestCase
         
         $this->quoteItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getChildren', 'getProductId', 'getQty', 'getSku'])
+            ->setMethods(['getProductId', 'getQty'])
             ->getMock();
     
         $this->event->expects($this->any())->method('getQuoteItem')
@@ -48,8 +47,6 @@ class RemoveFromCartTest extends \PHPUnit\Framework\TestCase
     
     public function testCallJsWithSimpleProduct()
     {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([]));
         $this->quoteItem->expects($this->any())->method('getProductId')
             ->will($this->returnValue($this->simpleProductId));
         $this->quoteItem->expects($this->any())->method('getQty')
@@ -62,34 +59,12 @@ class RemoveFromCartTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
     
-    public function testCallJsWithConfigurableProductWithSku()
+    public function testCallJsWithConfigurableProduct()
     {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([$this->quoteItem]));
-        $this->quoteItem->expects($this->any())->method('getQty')
-            ->will($this->returnValue($this->productQuantity));
-        $this->quoteItem->expects($this->any())->method('getSku')
-            ->will($this->returnValue($this->productSku));
         $this->quoteItem->expects($this->any())->method('getProductId')
             ->will($this->returnValue($this->configurableProductId));
-        
-        $expected = "window.metrilo.removeFromCart('" . $this->productSku . "', " . $this->productQuantity . ");";
-        
-        $result = $this->removeFromCartEvent->callJS();
-        
-        $this->assertSame($expected, $result);
-    }
-    
-    public function testCallJsWithConfigurableProductWithoutSku()
-    {
-        $this->quoteItem->expects($this->any())->method('getChildren')
-            ->will($this->returnValue([$this->quoteItem]));
         $this->quoteItem->expects($this->any())->method('getQty')
             ->will($this->returnValue($this->productQuantity));
-        $this->quoteItem->expects($this->any())->method('getSku')
-            ->will($this->returnValue(''));
-        $this->quoteItem->expects($this->any())->method('getProductId')
-            ->will($this->returnValue($this->configurableProductId));
         
         $expected = "window.metrilo.removeFromCart('" .
             $this->configurableProductId . "', " . $this->productQuantity . ");";


### PR DESCRIPTION
Reworked parent child relation to use id instead of sku and casted item quantity to integer type for add/remove cart and order events. Also adjusted unit tests after modification.