### PR TITLE
KYP-1197: Create custom event and tag for newsletter subscribers on Magento 2

### DIFF
--- a/Model/Events/CustomEvent.php
+++ b/Model/Events/CustomEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Metrilo\Analytics\Model\Events;
+
+class CustomEvent
+{
+    public function __construct(
+        $customEvent
+    ) {
+        $this->customEvent = $customEvent;
+    }
+    public function callJS()
+    {
+        return 'window.metrilo.customEvent("' . $this->customEvent . '");';
+    }
+}

--- a/Test/Unit/Observer/CustomerTest.php
+++ b/Test/Unit/Observer/CustomerTest.php
@@ -150,7 +150,7 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
     
         $this->sessionEvents = $this->getMockBuilder(SessionEvents::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSessionEvents'])
+            ->setMethods(['addSessionEvent'])
             ->getMock();
         
         $this->customerObserver = new Customer(
@@ -197,7 +197,7 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
         $this->observer->expects($this->at(3))->method('getName')
             ->will($this->returnValue('customer_register_success'));
     
-        $this->sessionEvents->expects($this->any())->method('addSessionEvents')
+        $this->sessionEvents->expects($this->any())->method('addSessionEvent')
             ->with(
                 self::logicalOr(
                     $this->isInstanceOf(IdentifyCustomer::class),


### PR DESCRIPTION

===

Jira story [#KYP-1197](https://metrilojira.atlassian.net/browse/KYP-1197) in project *Know Your Power*:

> Currently, there is no specific event or tag coming for the newsletter subscribers from Magento 2 store.
> 
> We need that in order to trigger automated emails and filer customers in the Customer Database.
> 
> The event should be “subscribed”
> 
> The tag should be “newsletter”