### PR TITLE
KYP-1444: Remove names generation from the magento newsletter form

### DIFF
--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -71,7 +71,7 @@ class Customer implements ObserverInterface
                     return new MetriloCustomer(
                         $subscriber->getStoreId(),
                         $subscriberEmail,
-                        strtotime($subscriber->getData('change_status_at')) * 1000,
+                        time() * 1000,
                         '',
                         '',
                         true,

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -72,8 +72,8 @@ class Customer implements ObserverInterface
                         $subscriber->getStoreId(),
                         $subscriberEmail,
                         strtotime($subscriber->getData('change_status_at')) * 1000,
-                        $subscriberEmail,
-                        $subscriberEmail,
+                        '',
+                        '',
                         true,
                         ['Newsletter']
                     );


### PR DESCRIPTION
Removing email assigned to first/last name for default newsletter customer event