### PR TITLE
2.1.0

### DIFF
--- a/Api/Connection.php
+++ b/Api/Connection.php
@@ -2,30 +2,55 @@
 
 namespace Metrilo\Analytics\Api;
 
+use Laminas\Uri\UriFactory;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Framework\Serialize\Serializer\Json;
+
 class Connection
 {
+    private CurlFactory $curlFactory;
+
+    private Json $json;
+
+    public function __construct(
+        CurlFactory $curlFactory,
+        Json $json
+    ) {
+        $this->curlFactory = $curlFactory;
+        $this->json = $json;
+    }
+
     /**
      * Create HTTP POST request to URL
      *
-     * @param String $url
-     * @param Array $bodyArray
-     * @return void
+     * @param string $url
+     * @param array|null $bodyArray
+     * @param string $secret
+     *
+     * @return array
      */
-    public function post($url, $bodyArray = false, $secret)
+    public function post($url, $bodyArray = null, $secret = ''): array
     {
-        $parsedUrl = parse_url($url);
+        $parsedUrl = UriFactory::factory($url);
         $headers = [
-            'Content-Type: application/json',
-            'Accept: */*',
-            'User-Agent: HttpClient/1.0.0',
-            'Connection: Close',
-            'Host: '.$parsedUrl['host']
+            'Content-Type' => 'application/json',
+            'Accept' => '*/*',
+            'User-Agent' => 'HttpClient/1.0.0',
+            'Connection' => 'Close',
+            'Host' => $parsedUrl->getHost()
         ];
-        
-        $headers[] = 'X-Digest: ' . hash_hmac('sha256', json_encode($bodyArray), $secret);
+        try {
+            $body = $this->json->serialize($bodyArray);
+        } catch (\InvalidArgumentException) {
+            $body = '';
+        }
 
-        $encodedBody = $bodyArray ? json_encode($bodyArray) : '';
-        return $this->curlCall($url, $headers, $encodedBody);
+        if ($body) {
+            $headers['X-Digest'] = hash_hmac('sha256', $body, (string)$secret);
+        }
+
+        return $this->curlCall($url, $headers, $body);
     }
 
     /**
@@ -34,30 +59,29 @@ class Connection
      * @param string $url
      * @param array $headers
      * @param string $body
-     * @param string $method
-     * @return void
+     * @return array
      */
-    private function curlCall($url, $headers = [], $body = '', $method = "POST")
+    private function curlCall(string $url, array $headers = [], string $body = ''): array
     {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_COOKIESESSION, true);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, 2000);
-        curl_setopt($curl, CURLOPT_TIMEOUT_MS, 3000);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-        curl_setopt($curl, CURLOPT_ENCODING, 'gzip');
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
+        /** @var Curl $curl */
+        $curl = $this->curlFactory->create();
 
-        $response = curl_exec($curl);
-        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
+        $curl->setOptions([
+            CURLOPT_COOKIESESSION => true,
+            CURLOPT_CONNECTTIMEOUT_MS => 2000,
+            CURLOPT_TIMEOUT_MS => 3000,
+            CURLOPT_ENCODING => 'gzip',
+            CURLOPT_SSL_VERIFYPEER => false
+        ]);
+        foreach ($headers as $header => $value) {
+            $curl->addHeader($header, $value);
+        }
+
+        $curl->post($url, $body);
 
         return [
-            'response' => $response,
-            'code' => $code
+            'response' => $curl->getBody(),
+            'code' => $curl->getStatus()
         ];
     }
 }

--- a/Block/Analytics.php
+++ b/Block/Analytics.php
@@ -1,54 +1,91 @@
 <?php
-    
+
 namespace Metrilo\Analytics\Block;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\SessionEvents;
+use Metrilo\Analytics\Model\Events\CartView;
+use Metrilo\Analytics\Model\Events\CatalogSearch;
+use Metrilo\Analytics\Model\Events\CategoryView;
+use Metrilo\Analytics\Model\Events\CheckoutView;
+use Metrilo\Analytics\Model\Events\PageView;
+use Metrilo\Analytics\Model\Events\ProductView;
 
 class Analytics extends Template
 {
+    private Data $helper;
+
+    private SessionEvents $sessionEvents;
+
+    private ProductView $productViewEvent;
+
+    private PageView $pageViewEvent;
+
+    private CategoryView $categoryViewEvent;
+
+    private CatalogSearch $catalogSearchEvent;
+
+    private CartView $cartViewEvent;
+
+    private CheckoutView $checkoutViewEvent;
+
+    /**
+     * @param Context $context
+     * @param Data $helper
+     * @param SessionEvents $sessionEvents
+     * @param ProductView $productViewEvent
+     * @param PageView $pageViewEvent
+     * @param CategoryView $categoryViewEvent
+     * @param CatalogSearch $catalogSearchEvent
+     * @param CartView $cartViewEvent
+     * @param CheckoutView $checkoutViewEvent
+     * @param array $data
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function __construct(
-        Context                                       $context,
-        \Magento\Framework\App\Action\Context         $actionContext,
-        \Metrilo\Analytics\Helper\Data                $helper,
-        \Metrilo\Analytics\Helper\SessionEvents       $sessionEvents,
-        \Metrilo\Analytics\Model\Events\ProductView   $productViewEvent,
-        \Metrilo\Analytics\Model\Events\PageView      $pageViewEvent,
-        \Metrilo\Analytics\Model\Events\CategoryView  $categoryViewEvent,
-        \Metrilo\Analytics\Model\Events\CatalogSearch $catalogSearchEvent,
-        \Metrilo\Analytics\Model\Events\CartView      $cartViewEvent,
-        \Metrilo\Analytics\Model\Events\CheckoutView  $checkoutViewEvent,
+        Context $context,
+        Data $helper,
+        SessionEvents $sessionEvents,
+        ProductView $productViewEvent,
+        PageView $pageViewEvent,
+        CategoryView $categoryViewEvent,
+        CatalogSearch $catalogSearchEvent,
+        CartView $cartViewEvent,
+        CheckoutView $checkoutViewEvent,
         array $data = []
     ) {
-        $this->actionContext      = $actionContext;
-        $this->helper             = $helper;
-        $this->sessionEvents      = $sessionEvents;
-        $this->productViewEvent   = $productViewEvent;
-        $this->pageViewEvent      = $pageViewEvent;
-        $this->categoryViewEvent  = $categoryViewEvent;
+        $this->helper = $helper;
+        $this->sessionEvents = $sessionEvents;
+        $this->productViewEvent = $productViewEvent;
+        $this->pageViewEvent = $pageViewEvent;
+        $this->categoryViewEvent = $categoryViewEvent;
         $this->catalogSearchEvent = $catalogSearchEvent;
-        $this->cartViewEvent      = $cartViewEvent;
-        $this->checkoutViewEvent  = $checkoutViewEvent;
+        $this->cartViewEvent = $cartViewEvent;
+        $this->checkoutViewEvent = $checkoutViewEvent;
         parent::__construct($context, $data);
     }
-    
-    public function getLibraryUrl()
+
+    public function getLibraryUrl(): string
     {
         return $this->helper->getApiEndpoint() . '/tracking.js?token=' .
-               $this->helper->getApiToken($this->helper->getStoreId());
+            $this->helper->getApiToken($this->helper->getStoreId());
     }
-    
+
     protected function _toHtml()
     {
         if (!$this->helper->isEnabled($this->helper->getStoreId())) {
             return '';
         }
+
         return parent::_toHtml();
     }
-    
+
     public function getEvent()
     {
-        switch ($this->actionContext->getRequest()->getFullActionName()) {
+        switch ($this->_request->getFullActionName()) {
             // product view pages
             case 'catalog_product_view':
                 return $this->productViewEvent->callJS();
@@ -56,9 +93,8 @@ class Analytics extends Template
             case 'catalog_category_view':
                 return $this->categoryViewEvent->callJS();
             // catalog search pages
-            case 'catalogsearch_result_index':
-                return $this->catalogSearchEvent->callJS();
             // catalog advanced result page
+            case 'catalogsearch_result_index':
             case 'catalogsearch_advanced_result':
                 return $this->catalogSearchEvent->callJS();
             // cart view pages
@@ -72,11 +108,12 @@ class Analytics extends Template
                 return $this->pageViewEvent->callJS();
         }
     }
-    
+
     public function getEvents()
     {
-        $sessionEvents   = $this->sessionEvents->getSessionEvents();
+        $sessionEvents = $this->sessionEvents->getSessionEvents();
         $sessionEvents[] = $this->getEvent();
+
         return $sessionEvents;
     }
 }

--- a/Block/System/Config/Button/Import.php
+++ b/Block/System/Config/Button/Import.php
@@ -2,44 +2,60 @@
 
 namespace Metrilo\Analytics\Block\System\Config\Button;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Model\CategoryData;
+use Metrilo\Analytics\Model\CustomerData;
+use Metrilo\Analytics\Model\OrderData;
+use Metrilo\Analytics\Model\ProductData;
 
 /**
  * Block for import button in metrilo configuration
  *
  * @author Miroslav Petrov <miro91tn@gmail.com>
  */
-class Import extends \Magento\Config\Block\System\Config\Form\Field
+class Import extends Field
 {
     /**
      * Path to block template
      */
-    const CHECK_TEMPLATE = 'system/config/button/import.phtml';
+    private const CHECK_TEMPLATE = 'system/config/button/import.phtml';
+
+    private Data $helper;
+
+    private CustomerData $customerData;
+
+    private CategoryData $categoryData;
+
+    private ProductData $productData;
+
+    private OrderData $orderData;
 
     /**
-     * Import constructor.
-     *
-     * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Metrilo\Analytics\Helper\Data $helper
+     * @param Context $context
+     * @param Data $helper
+     * @param CustomerData $customerData
+     * @param CategoryData $categoryData
+     * @param ProductData $productData
+     * @param OrderData $orderData
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Metrilo\Analytics\Helper\Data          $helper,
-        \Metrilo\Analytics\Model\CustomerData   $customerData,
-        \Metrilo\Analytics\Model\CategoryData   $categoryData,
-        \Metrilo\Analytics\Model\ProductData    $productData,
-        \Metrilo\Analytics\Model\OrderData      $orderData,
-        \Magento\Framework\App\Request\Http     $request,
+        Context $context,
+        Data $helper,
+        CustomerData $customerData,
+        CategoryData $categoryData,
+        ProductData $productData,
+        OrderData $orderData,
         array $data = []
     ) {
-        $this->helper       = $helper;
+        $this->helper = $helper;
         $this->customerData = $customerData;
         $this->categoryData = $categoryData;
-        $this->productData  = $productData;
-        $this->orderData    = $orderData;
-        $this->request      = $request;
+        $this->productData = $productData;
+        $this->orderData = $orderData;
         parent::__construct($context, $data);
     }
 
@@ -54,25 +70,29 @@ class Import extends \Magento\Config\Block\System\Config\Form\Field
         if (!$this->getTemplate()) {
             $this->setTemplate(self::CHECK_TEMPLATE);
         }
+
         return $this;
     }
 
     /**
      * Render button and remove scope label
      *
-     * @param  AbstractElement $element
+     * @param AbstractElement $element
+     *
      * @return string
      */
     public function render(AbstractElement $element)
     {
         $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+
         return parent::render($element);
     }
 
     /**
      * Get block custom template html for the button
      *
-     * @param  AbstractElement $element
+     * @param AbstractElement $element
+     *
      * @return string
      */
     protected function _getElementHtml(AbstractElement $element)
@@ -84,6 +104,7 @@ class Import extends \Magento\Config\Block\System\Config\Form\Field
                 'html_id' => $element->getHtmlId(),
             ]
         );
+
         return $this->_toHtml();
     }
 
@@ -95,9 +116,10 @@ class Import extends \Magento\Config\Block\System\Config\Form\Field
     public function buttonEnabled()
     {
         $storeId = $this->getStoreId();
-         return $this->helper->isEnabled($storeId)
-             && $this->helper->getApiToken($storeId)
-             && $this->helper->getApiSecret($storeId);
+
+        return $this->helper->isEnabled($storeId)
+            && $this->helper->getApiToken($storeId)
+            && $this->helper->getApiSecret($storeId);
     }
 
     /**
@@ -114,17 +136,17 @@ class Import extends \Magento\Config\Block\System\Config\Form\Field
     {
         return $this->orderData->getOrderChunks($this->getStoreId());
     }
-    
+
     public function getCustomerChunks()
     {
         return $this->customerData->getCustomerChunks($this->getStoreId());
     }
-    
+
     public function getCategoryChunks()
     {
         return $this->categoryData->getCategoryChunks($this->getStoreId());
     }
-    
+
     public function getProductChunks()
     {
         return $this->productData->getProductChunks($this->getStoreId());
@@ -135,8 +157,8 @@ class Import extends \Magento\Config\Block\System\Config\Form\Field
      *
      * @return int
      */
-    public function getStoreId()
+    public function getStoreId(): int
     {
-        return (int)$this->request->getParam('store', 0);
+        return (int)$this->_request->getParam('store', 0);
     }
 }

--- a/Controller/Adminhtml/Import/Ajax.php
+++ b/Controller/Adminhtml/Import/Ajax.php
@@ -2,60 +2,130 @@
 
 namespace Metrilo\Analytics\Controller\Adminhtml\Import;
 
-class Ajax extends \Magento\Backend\App\Action
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Metrilo\Analytics\Helper\Activity;
+use Metrilo\Analytics\Helper\ApiClient;
+use Metrilo\Analytics\Helper\CategorySerializer;
+use Metrilo\Analytics\Helper\CustomerSerializer;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\DeletedProductSerializer;
+use Metrilo\Analytics\Helper\OrderSerializer;
+use Metrilo\Analytics\Helper\ProductSerializer;
+use Metrilo\Analytics\Model\CategoryData;
+use Metrilo\Analytics\Model\CustomerData;
+use Metrilo\Analytics\Model\DeletedProductData;
+use Metrilo\Analytics\Model\OrderData;
+use Metrilo\Analytics\Model\ProductData;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class Ajax implements HttpPostActionInterface
 {
+    private Data $helper;
+
+    private CustomerData $customerData;
+
+    private CategoryData $categoryData;
+
+    private DeletedProductData $deletedProductData;
+
+    private ProductData $productData;
+
+    private CustomerSerializer $customerSerializer;
+
+    private CategorySerializer $categorySerializer;
+
+    private JsonFactory $resultJsonFactory;
+
+    private ApiClient $apiClient;
+
+    private OrderSerializer $orderSerializer;
+
+    private DeletedProductSerializer $deletedProductSerializer;
+
+    private ProductSerializer $productSerializer;
+
+    private OrderData $orderData;
+
+    private Activity $activityHelper;
+
+    private Http $request;
+
+    /**
+     * @param Data $helper
+     * @param CustomerData $customerData
+     * @param CategoryData $categoryData
+     * @param ProductData $productData
+     * @param DeletedProductData $deletedProductData
+     * @param OrderData $orderData
+     * @param CustomerSerializer $customerSerializer
+     * @param CategorySerializer $categorySerializer
+     * @param ProductSerializer $productSerializer
+     * @param DeletedProductSerializer $deletedProductSerializer
+     * @param OrderSerializer $orderSerializer
+     * @param ApiClient $apiClient
+     * @param Activity $activityHelper
+     * @param Http $request
+     * @param JsonFactory $resultJsonFactory
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function __construct(
-        \Magento\Backend\App\Action\Context                $context,
-        \Metrilo\Analytics\Helper\Data                     $helper,
-        \Metrilo\Analytics\Model\CustomerData              $customerData,
-        \Metrilo\Analytics\Model\CategoryData              $categoryData,
-        \Metrilo\Analytics\Model\ProductData               $productData,
-        \Metrilo\Analytics\Model\DeletedProductData        $deletedProductData,
-        \Metrilo\Analytics\Model\OrderData                 $orderData,
-        \Metrilo\Analytics\Helper\CustomerSerializer       $customerSerializer,
-        \Metrilo\Analytics\Helper\CategorySerializer       $categorySerializer,
-        \Metrilo\Analytics\Helper\ProductSerializer        $productSerializer,
-        \Metrilo\Analytics\Helper\DeletedProductSerializer $deletedProductSerializer,
-        \Metrilo\Analytics\Helper\OrderSerializer          $orderSerializer,
-        \Metrilo\Analytics\Helper\ApiClient                $apiClient,
-        \Metrilo\Analytics\Helper\Activity                 $activityHelper,
-        \Magento\Framework\App\Request\Http                $request,
-        \Magento\Framework\Controller\Result\JsonFactory   $resultJsonFactory
+        Data $helper,
+        CustomerData $customerData,
+        CategoryData $categoryData,
+        ProductData $productData,
+        DeletedProductData $deletedProductData,
+        OrderData $orderData,
+        CustomerSerializer $customerSerializer,
+        CategorySerializer $categorySerializer,
+        ProductSerializer $productSerializer,
+        DeletedProductSerializer $deletedProductSerializer,
+        OrderSerializer $orderSerializer,
+        ApiClient $apiClient,
+        Activity $activityHelper,
+        Http $request,
+        JsonFactory $resultJsonFactory
     ) {
-        parent::__construct($context);
-        $this->helper                   = $helper;
-        $this->customerData             = $customerData;
-        $this->categoryData             = $categoryData;
-        $this->productData              = $productData;
-        $this->deletedProductData       = $deletedProductData;
-        $this->orderData                = $orderData;
-        $this->customerSerializer       = $customerSerializer;
-        $this->categorySerializer       = $categorySerializer;
-        $this->productSerializer        = $productSerializer;
+        $this->helper = $helper;
+        $this->customerData = $customerData;
+        $this->categoryData = $categoryData;
+        $this->productData = $productData;
+        $this->deletedProductData = $deletedProductData;
+        $this->orderData = $orderData;
+        $this->customerSerializer = $customerSerializer;
+        $this->categorySerializer = $categorySerializer;
+        $this->productSerializer = $productSerializer;
         $this->deletedProductSerializer = $deletedProductSerializer;
-        $this->orderSerializer          = $orderSerializer;
-        $this->apiClient                = $apiClient;
-        $this->activityHelper           = $activityHelper;
-        $this->request                  = $request;
-        $this->resultJsonFactory        = $resultJsonFactory;
+        $this->orderSerializer = $orderSerializer;
+        $this->apiClient = $apiClient;
+        $this->activityHelper = $activityHelper;
+        $this->request = $request;
+        $this->resultJsonFactory = $resultJsonFactory;
     }
 
     /**
      * Import history by chunks
      *
+     * @return ResultInterface
      * @throws \Exception
-     * @return string
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function execute()
+    public function execute(): ResultInterface
     {
+        $result['success'] = false;
+        $jsonResponse = $this->resultJsonFactory->create();
         try {
-            $result['success'] = false;
-            $jsonFactory       = $this->resultJsonFactory->create();
-            $storeId           = (int)$this->request->getParam('storeId');
-            $chunkId           = (int)$this->request->getParam('chunkId');
-            $importType        = (string)$this->request->getParam('importType');
-            $client            = $this->apiClient->getClient($storeId);
-            
+            $storeId = (int)$this->request->getParam('storeId');
+            $chunkId = (int)$this->request->getParam('chunkId');
+            $importType = (string)$this->request->getParam('importType');
+            $client = $this->apiClient->getClient($storeId);
+
             switch ($importType) {
                 case 'customers':
                     if ($chunkId == 0) {
@@ -65,21 +135,21 @@ class Ajax extends \Magento\Backend\App\Action
                         $this->customerData->getCustomers($storeId, $chunkId),
                         $this->customerSerializer
                     );
-                    $result['success']   = $client->customerBatch($serializedCustomers);
+                    $result['success'] = $client->customerBatch($serializedCustomers);
                     break;
                 case 'categories':
                     $serializedCategories = $this->serializeRecords(
                         $this->categoryData->getCategories($storeId, $chunkId),
                         $this->categorySerializer
                     );
-                    $result['success']    = $client->categoryBatch($serializedCategories);
+                    $result['success'] = $client->categoryBatch($serializedCategories);
                     break;
                 case 'deletedProducts':
                     $deletedProductOrders = $this->deletedProductData->getDeletedProductOrders($storeId);
                     if ($deletedProductOrders) {
-                        $helperObject              = $this->helper; // for backward compatibility for php ~5.5, ~5.6
+                        $helperObject = $this->helper; // for backward compatibility for php ~5.5, ~5.6
                         $serializedDeletedProducts = $this->deletedProductSerializer->serialize($deletedProductOrders);
-                        $deletedProductChunks      = array_chunk($serializedDeletedProducts, $helperObject::CHUNK_ITEMS);
+                        $deletedProductChunks = array_chunk($serializedDeletedProducts, $helperObject::CHUNK_ITEMS);
                         foreach ($deletedProductChunks as $chunk) {
                             $client->productBatch($chunk);
                         }
@@ -90,10 +160,10 @@ class Ajax extends \Magento\Backend\App\Action
                         $this->productData->getProducts($storeId, $chunkId),
                         $this->productSerializer
                     );
-                    $result['success']  = $client->productBatch($serializedProducts);
+                    $result['success'] = $client->productBatch($serializedProducts);
                     break;
                 case 'orders':
-                    $serializedOrders  = $this->serializeRecords(
+                    $serializedOrders = $this->serializeRecords(
                         $this->orderData->getOrders($storeId, $chunkId),
                         $this->orderSerializer
                     );
@@ -107,28 +177,28 @@ class Ajax extends \Magento\Backend\App\Action
                     break;
             }
 
-            return $jsonFactory->setData($result);
+            return $jsonResponse->setData($result);
         } catch (\Exception $e) {
             $this->helper->logError($e);
-            
-            return $jsonFactory->setData([
+
+            return $jsonResponse->setData([
                 'success' => false,
                 'message' => $e->getMessage()
             ]);
         }
     }
-    
+
     private function serializeRecords($records, $serializer)
     {
         $serializedData = [];
-        
+
         foreach ($records as $record) {
             $serializedRecord = $serializer->serialize($record);
             if ($serializedRecord) {
                 $serializedData[] = $serializedRecord;
             }
         }
-        
+
         return $serializedData;
     }
 }

--- a/CustomerData/PrivateData.php
+++ b/CustomerData/PrivateData.php
@@ -3,16 +3,19 @@
 namespace Metrilo\Analytics\CustomerData;
 
 use Magento\Customer\CustomerData\SectionSourceInterface;
+use Metrilo\Analytics\Helper\SessionEvents;
 
 class PrivateData implements SectionSourceInterface
 {
+    private SessionEvents $sessionEvents;
+
     public function __construct(
-        \Metrilo\Analytics\Helper\SessionEvents $sessionEvents
+        SessionEvents $sessionEvents
     ) {
         $this->sessionEvents = $sessionEvents;
     }
-    
-    public function getSectionData()
+
+    public function getSectionData(): array
     {
         $events = $this->sessionEvents->getSessionEvents();
         return ['events' => $events];

--- a/Helper/Activity.php
+++ b/Helper/Activity.php
@@ -2,30 +2,39 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class Activity extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+
+class Activity extends AbstractHelper
 {
+    private Data $dataHelper;
+
+    private ApiClient $apiClient;
+
     public function __construct(
-        \Metrilo\Analytics\Helper\Data      $dataHelper,
-        \Metrilo\Analytics\Helper\ApiClient $apiClient
+        Data $dataHelper,
+        ApiClient $apiClient,
+        Context $context
     ) {
+        parent::__construct($context);
         $this->dataHelper = $dataHelper;
-        $this->apiClient  = $apiClient;
+        $this->apiClient = $apiClient;
     }
-    
+
     public function createActivity($storeId, $type)
     {
-        $token    = $this->dataHelper->getApiToken($storeId);
-        $secret   = $this->dataHelper->getApiSecret($storeId);
+        $token = $this->dataHelper->getApiToken($storeId);
+        $secret = $this->dataHelper->getApiSecret($storeId);
         $endPoint = $this->dataHelper->getActivityEndpoint();
-        $client   = $this->apiClient->getClient($storeId);
-        
+        $client = $this->apiClient->getClient($storeId);
+
         $data = [
-            'type'   => $type,
+            'type' => $type,
             'secret' => $secret
         ];
-        
+
         $url = $endPoint . '/tracking/' . $token . '/activity';
-        
+
         return $client->createActivity($url, $data);
     }
 }

--- a/Helper/ApiClient.php
+++ b/Helper/ApiClient.php
@@ -2,30 +2,77 @@
 
 namespace Metrilo\Analytics\Helper;
 
-use \Metrilo\Analytics\Api\Client;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\ProductMetadata;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\Framework\Serialize\Serializer\Json;
+use Metrilo\Analytics\Api\ClientFactory;
 
-class ApiClient extends \Magento\Framework\App\Helper\AbstractHelper
+class ApiClient extends AbstractHelper
 {
+    private Data $helper;
+
+    private ProductMetadata $metaData;
+
+    private ClientFactory $clientFactory;
+
+    private ComponentRegistrarInterface $componentRegistrar;
+
+    private ReadFactory $readFactory;
+
+    private Json $json;
+
     public function __construct(
-        \Metrilo\Analytics\Helper\Data                $helper,
-        \Magento\Framework\App\ProductMetadata        $metaData,
-        \Magento\Framework\Module\ModuleListInterface $moduleList,
-        \Magento\Framework\Filesystem\DirectoryList   $dirList
+        Data $helper,
+        ProductMetadata $metaData,
+        ClientFactory $clientFactory,
+        ComponentRegistrarInterface $componentRegistrar,
+        ReadFactory $readFactory,
+        Json $json,
+        Context $context
     ) {
-        $this->helper       = $helper;
-        $this->metaData     = $metaData;
-        $this->moduleList   = $moduleList;
-        $this->dirList      = $dirList;
+        parent::__construct($context);
+        $this->helper = $helper;
+        $this->metaData = $metaData;
+        $this->clientFactory = $clientFactory;
+        $this->componentRegistrar = $componentRegistrar;
+        $this->readFactory = $readFactory;
+        $this->json = $json;
     }
 
     public function getClient($storeId)
     {
-        $helperObject  = $this->helper; // for backward compatibility for php ~5.5, ~5.6
-        $token         = $this->helper->getApiToken($storeId);
-        $secret        = $this->helper->getApiSecret($storeId);
-        $platform      = 'Magento ' . $this->metaData->getEdition() . ' ' . $this->metaData->getVersion();
-        $pluginVersion = $this->moduleList->getOne($helperObject::MODULE_NAME)['setup_version'];
-        $apiEndpoint   = $this->helper->getApiEndpoint();
-        return new Client($token, $secret, $platform, $pluginVersion, $apiEndpoint, $this->dirList->getPath('log'));
+        $token = $this->helper->getApiToken($storeId);
+        $secret = $this->helper->getApiSecret($storeId);
+        $platform = 'Magento ' . $this->metaData->getEdition() . ' ' . $this->metaData->getVersion();
+        $apiEndpoint = $this->helper->getApiEndpoint();
+
+        return $this->clientFactory->create(
+            [
+                'token' => $token,
+                'secret' => $secret,
+                'platform' => $platform,
+                'pluginVersion' => $this->getPluginVersion(),
+                'apiEndpoint' => $apiEndpoint,
+            ]
+        );
+    }
+
+    private function getPluginVersion(): ?string
+    {
+        try {
+            $modulePath = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $this->_getModuleName());
+            $read = $this->readFactory->create($modulePath);
+            $content = $read->readFile('composer.json');
+            $decoded = $this->json->unserialize($content);
+
+            return $decoded['version'] ?? null;
+        } catch (LocalizedException) {
+            return null;
+        }
     }
 }

--- a/Helper/CategorySerializer.php
+++ b/Helper/CategorySerializer.php
@@ -2,24 +2,32 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class CategorySerializer extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\StoreManagerInterface;
+
+class CategorySerializer extends AbstractHelper
 {
+    private StoreManagerInterface $storeManager;
+
     public function __construct(
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        Context $context
     ) {
         $this->storeManager = $storeManager;
+        parent::__construct($context);
     }
-    
+
     public function serialize($category)
     {
         $categoryId   = $category->getId();
         $storeId      = $category->getStoreId();
         $storeBaseUrl = $this->storeManager->getStore($storeId)->getBaseUrl(); // Used for multiwebsite config base url
-        
-        return array(
+
+        return [
             'id'   => $categoryId,
             'name' => $category->getName(),
             'url'  => $storeBaseUrl . $category->getRequestPath()
-        );
+        ];
     }
 }

--- a/Helper/CustomerSerializer.php
+++ b/Helper/CustomerSerializer.php
@@ -2,7 +2,9 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class CustomerSerializer extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+
+class CustomerSerializer extends AbstractHelper
 {
     public function serialize($customer)
     {
@@ -14,7 +16,7 @@ class CustomerSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             'subscribed'  => $customer->getSubscriberStatus(),
             'tags'        => $customer->getTags()
         ];
-        
+
         return $serializedCustomer;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -2,79 +2,85 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class Data extends \Magento\Framework\App\Helper\AbstractHelper
-{
-    const CHUNK_ITEMS = 50;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
 
-    const MODULE_NAME = 'Metrilo_Analytics';
+class Data extends AbstractHelper
+{
+    public const CHUNK_ITEMS = 50;
+
+    private StoreManagerInterface $storeManager;
+
+    private LoggerInterface $logger;
 
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $config,
-        \Magento\Store\Model\StoreManagerInterface         $storeManager
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger,
+        Context $context
     ) {
-        $this->config       = $config;
+        parent::__construct($context);
         $this->storeManager = $storeManager;
+        $this->logger = $logger;
     }
 
-    public function getStoreId()
+    public function getStoreId(): int
     {
         return (int)$this->storeManager->getStore()->getId();
     }
 
-    public function isEnabled($storeId)
+    public function isEnabled($storeId): bool
     {
-        return $this->config->getValue(
+        return $this->scopeConfig->isSetFlag(
             'metrilo_analytics/general/enable',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            ScopeInterface::SCOPE_STORE,
             $storeId
         );
     }
 
     public function getApiToken($storeId)
     {
-        return $this->config->getValue(
+        return $this->scopeConfig->getValue(
             'metrilo_analytics/general/api_key',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            ScopeInterface::SCOPE_STORE,
             $storeId
         );
     }
 
     public function getApiSecret($storeId)
     {
-        return $this->config->getValue(
+        return $this->scopeConfig->getValue(
             'metrilo_analytics/general/api_secret',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            ScopeInterface::SCOPE_STORE,
             $storeId
         );
     }
 
     public function getApiEndpoint()
     {
-        $apiEndpoint = $this->config->getValue(
+        $apiEndpoint = $this->scopeConfig->getValue(
             'metrilo_analytics/general/api_endpoint'
         );
-        
-        return ($apiEndpoint) ? $apiEndpoint : 'https://trk.mtrl.me';
+
+        return $apiEndpoint ?? 'https://trk.mtrl.me';
     }
 
     public function getActivityEndpoint()
     {
-        $activityEndpoint = $this->config->getValue(
+        $activityEndpoint = $this->scopeConfig->getValue(
             'metrilo_analytics/general/activity_endpoint'
         );
-        
-        return ($activityEndpoint) ? $activityEndpoint : 'https://p.metrilo.com';
+
+        return $activityEndpoint ?? 'https://p.metrilo.com';
     }
 
     public function logError($exception)
     {
-        if ($exception instanceof \Exception) {
-            $this->log($exception->getMessage());
-        } else {
-            $this->log($exception);
-        }
+        $this->logger->error($exception);
     }
-    
+
     public function getStoreIdsPerProject($storeIds)
     {
         $storeIdConfigMap = [];
@@ -82,30 +88,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             if ($storeId == 0 || !$this->isEnabled($storeId)) { // store 0 is always admin
                 continue;
             }
-            
-            $storeIdConfigMap[$storeId] = $this->config
+
+            $storeIdConfigMap[$storeId] = $this->scopeConfig
                 ->getValue(
                     'metrilo_analytics/general/api_key',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                    ScopeInterface::SCOPE_STORE,
                     $storeId
                 );
         }
         $storeIdConfigMap = array_unique($storeIdConfigMap);
-        
+
         return array_keys($storeIdConfigMap);
-    }
-    
-    private function log($value)
-    {
-        $logLocation = BP . '/var/log/metrilo.log';
-        if (file_exists($logLocation) && filesize($logLocation) > 10 * 1024 * 1024) {
-            unlink($logLocation);
-        }
-        
-        $writer = new \Zend\Log\Writer\Stream($logLocation);
-        $logger = new \Zend\Log\Logger();
-        $logger->addWriter($writer);
-        
-        $logger->err($value);
     }
 }

--- a/Helper/DeletedProductSerializer.php
+++ b/Helper/DeletedProductSerializer.php
@@ -2,83 +2,85 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class DeletedProductSerializer extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Catalog\Model\Product\Type;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
+
+class DeletedProductSerializer extends AbstractHelper
 {
-    public function serialize($deletedProductOrders)
+
+    public function serialize(Collection $deletedProductOrders): array
     {
-        $productBatch = [];
+        $batch = [];
+
+        /** @var Order $order */
         foreach ($deletedProductOrders as $order) {
-            foreach ($order->getAllItems() as $item) {
-                $parentProduct  = '';
-                $productOptions = [];
-                
-                $parentItemId   = $item->getParentItemId();
-                $itemId         = $item->getProductId();
-                $itemSku        = $item->getSku();
-                $itemName       = $item->getName();
-                
-                if ($item->getProductType() == 'configurable' || $this->presentInBatch($itemId, $productBatch)) {
-                    continue;
+            $this->serializeOrder($order, $batch);
+        }
+
+        return $batch;
+    }
+
+    private function serializeOrder(Order $order, array &$batch): void
+    {
+        foreach ($order->getAllItems() as $item) {
+            if (isset($batch[$item->getProductId()]) && ($this->hasChildren($item) || !$item->getParentItemId())) {
+                continue;
+            }
+
+            if ($this->hasChildren($item) || !$item->getParentItemId()) {
+                $batch[$item->getProductId()] = $this->getRootProductData($item);
+            } elseif ($item->getParentItemId()) {
+                $parentItem = $order->getItemById($item->getParentItemId());
+                if (isset($batch[$parentItem->getProductId()])) {
+                    $batch[$parentItem->getProductId()]['options'][$item->getProductId()] =
+                        $this->getSimpleOptionData($item, $parentItem);
+                } else {
+                    $batch[$parentItem->getProductId()] = $this->serializeSimpleWithParent($item, $parentItem);
                 }
-                
-                if ($parentItemId) {
-                    $parentProduct = $order->getItemById($parentItemId);
-                    
-                    if ($parentProduct) {
-                        $productOptions[] = [
-                            'id'       => $itemId,
-                            'sku'      => $itemSku,
-                            'name'     => $itemName,
-                            'price'    => $parentProduct->getPrice(),
-                            'imageUrl' => ''
-                        ];
-                        
-                        $parentIndex = $this->getProductBatchIndexById($parentProduct->getProductId(), $productBatch);
-                        if ($parentIndex !== false) {
-                            if ($this->presentInBatchProductOptions($itemId, $productBatch[$parentIndex]['options'])) {
-                                continue;
-                            }
-                            $productBatch[$parentIndex]['options'] = array_merge(
-                                $productBatch[$parentIndex]['options'],
-                                $productOptions
-                            );
-                            continue;
-                        }
-                    }
-                }
-                
-                $productBatch[] = [
-                    'categories' => [],
-                    'id'         => $parentProduct ? $parentProduct->getProductId() : $itemId,
-                    'sku'        => $itemSku,
-                    'imageUrl'   => '',
-                    'name'       => $parentProduct ? $parentProduct->getName() : $itemName,
-                    'price'      => $parentProduct ? 0 : $item->getPrice(),
-                    'url'        => '',
-                    'options'    => $productOptions
-                ];
             }
         }
-        
-        return $productBatch;
     }
-    
-    private function getProductBatchIndexById($productId, $productBatch)
+
+    private function getSimpleOptionData(Item $item, Item $parentItem): array
     {
-        return array_search($productId, array_column($productBatch, 'id'));
+        return [
+            'id' => $item->getProductId(),
+            'sku' => $item->getSku(),
+            'name' => $item->getName(),
+            'price' => $parentItem->getPrice(),
+            'imageUrl' => '',
+        ];
     }
-    
-    private function presentInBatch($id, $batch)
+
+    private function getRootProductData(Item $item): array
     {
-        $productIndex = $this->getProductBatchIndexById($id, $batch);
-        
-        return ($productIndex) ? true : false;
+        return [
+            'categories' => [],
+            'id' => $item->getProductId(),
+            'sku' => $item->getSku(),
+            'imageUrl' => '',
+            'name' => $item->getName(),
+            'price' => $this->hasChildren($item) ? 0 : $item->getPrice(),
+            'url' => '',
+            'options' => []
+        ];
     }
-    
-    private function presentInBatchProductOptions($id, $batchOptions)
+
+    private function serializeSimpleWithParent(Item $item, Item $parentItem): array
     {
-        $productOptionIndex = $this->getProductBatchIndexById($id, $batchOptions);
-        
-        return ($productOptionIndex) ? true : false;
+        $data = $this->getRootProductData($parentItem);
+        $data['options'][$item->getProductId()] = $this->getSimpleOptionData($item, $parentItem);
+
+        return $data;
+    }
+
+    private function hasChildren(Item $item): bool
+    {
+        return $item->getProductType() === Configurable::TYPE_CODE ||
+            $item->getProductType() === Type::TYPE_BUNDLE;
     }
 }

--- a/Helper/OrderSerializer.php
+++ b/Helper/OrderSerializer.php
@@ -2,11 +2,12 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+
+class OrderSerializer extends AbstractHelper
 {
     public function serialize($order)
     {
-
         $orderItems    = $order->getAllItems();
         $orderProducts = [];
 
@@ -15,7 +16,7 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             if ($itemType === 'configurable' || $itemType === 'bundle') {
                 continue; // exclude configurable/bundle parent product returned by getAllItems() method
             }
-            
+
             $orderProducts[] = [
                 'productId'  => $orderItem->getProductId(),
                 'quantity'   => (int)$orderItem->getQtyOrdered()
@@ -37,7 +38,7 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
             "postcode"      => $orderBillingData->getPostcode(),
             "paymentMethod" => $order->getPayment()->getMethodInstance()->getTitle()
         ];
-        
+
         if (!empty($order->getCustomerEmail())) {
             $customerEmail = $order->getCustomerEmail();
         } elseif (!empty($orderPhone)) {
@@ -45,7 +46,7 @@ class OrderSerializer extends \Magento\Framework\App\Helper\AbstractHelper
         } else {
             return false;
         }
-        
+
         $serializedOrder = [
             'id'        => $order->getIncrementId(),
             'createdAt' => strtotime($order->getCreatedAt()) * 1000,

--- a/Helper/ProductImageUrl.php
+++ b/Helper/ProductImageUrl.php
@@ -2,19 +2,28 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class ProductImageUrl extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ProductImageUrl extends AbstractHelper
 {
+    private StoreManagerInterface $storeManager;
+
     public function __construct(
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        Context $context
     ) {
+        parent::__construct($context);
         $this->storeManager = $storeManager;
     }
-    
+
     public function getProductImageUrl($imageUrlRequestPath)
     {
         return $this->storeManager
                 ->getStore()
-                ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' .
+                ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' .
                 $imageUrlRequestPath;
     }
 }

--- a/Helper/ProductSerializer.php
+++ b/Helper/ProductSerializer.php
@@ -2,50 +2,68 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class ProductSerializer extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ProductSerializer extends AbstractHelper
 {
+    private ProductOptions $productOptions;
+
+    private StoreManagerInterface $storeManager;
+
+    private ProductImageUrl $productImageUrl;
+
+    /**
+     * @param StoreManagerInterface $storeManager
+     * @param ProductOptions $productOptions
+     * @param ProductImageUrl $productImageUrl
+     * @param Context $context
+     */
     public function __construct(
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Metrilo\Analytics\Helper\ProductOptions   $productOptions
+        StoreManagerInterface $storeManager,
+        ProductOptions $productOptions,
+        ProductImageUrl $productImageUrl,
+        Context $context
     ) {
-        $this->storeManager   = $storeManager;
+        parent::__construct($context);
+        $this->storeManager = $storeManager;
         $this->productOptions = $productOptions;
+        $this->productImageUrl = $productImageUrl;
     }
-    
+
     public function serialize($product)
     {
-        $storeId     = $product->getStoreId();
-        $productId   = $product->getId();
+        $storeId = $product->getStoreId();
+        $productId = $product->getId();
         $productType = $product->getTypeId();
-        
+
         if ($productType === 'simple' && $this->productOptions->getParentIds($productId, $productType) != []) {
             return false;
         }
-        
+
         $productImage = $product->getImage();
         $productPrice = $product->getPrice();
-        $imageUrl     = (!empty($productImage)) ? $this->productOptions
-            ->productImageUrl
-            ->getProductImageUrl($productImage) : '';
-        $price        = (!empty($productPrice)) ? $productPrice : 0; // Does not return grouped/bundled parent price
+        $imageUrl = (!empty($productImage)) ? $this->productImageUrl->getProductImageUrl($productImage) : '';
+        $price = (!empty($productPrice)) ? $productPrice : 0; // Does not return grouped/bundled parent price
         $specialPrice = $product->getSpecialPrice();
-        $url          = $this->storeManager->getStore($storeId)->getBaseUrl() . $product->getRequestPath();
-        
+        $url = $this->storeManager->getStore($storeId)->getBaseUrl() . $product->getRequestPath();
+
         if ($productType === 'configurable' || $productType === 'bundle' || $productType === 'grouped') {
             $productOptions = $this->productOptions->getParentOptions($product);
         } else {
             $productOptions = [];
         }
-        
+
         return [
             'categories' => $product->getCategoryIds(),
-            'id'         => $productId,
-            'sku'        => $product->getSku(),
-            'imageUrl'   => $imageUrl,
-            'name'       => $product->getName(),
-            'price'      => $specialPrice ? $specialPrice : $price,
-            'url'        => $url,
-            'options'    => $productOptions
+            'id' => $productId,
+            'sku' => $product->getSku(),
+            'imageUrl' => $imageUrl,
+            'name' => $product->getName(),
+            'price' => $specialPrice ? $specialPrice : $price,
+            'url' => $url,
+            'options' => $productOptions
         ];
     }
 }

--- a/Helper/SessionEvents.php
+++ b/Helper/SessionEvents.php
@@ -2,27 +2,38 @@
 
 namespace Metrilo\Analytics\Helper;
 
-class SessionEvents extends \Magento\Framework\App\Helper\AbstractHelper
+use Magento\Catalog\Model\Session;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+
+/**
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
+ */
+class SessionEvents extends AbstractHelper
 {
-    private $metriloSessionEvents = 'metrilo_session_key';
-    
+    private string $metriloSessionEvents = 'metrilo_session_key';
+
+    private Session $catalogSession;
+
     public function __construct(
-        \Magento\Catalog\Model\Session $catalogSession
+        Session $catalogSession,
+        Context $context
     ) {
+        parent::__construct($context);
         $this->catalogSession = $catalogSession;
     }
-    
+
     public function getSessionEvents()
     {
         $sessionEvents = $this->catalogSession->getData($this->metriloSessionEvents, true);
-        
+
         if ($sessionEvents === null) {
             $sessionEvents = [];
         }
-        
+
         return $sessionEvents;
     }
-    
+
     public function addSessionEvent($data)
     {
         $events   = $this->getSessionEvents();

--- a/Model/CategoryData.php
+++ b/Model/CategoryData.php
@@ -2,12 +2,17 @@
 
 namespace Metrilo\Analytics\Model;
 
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
+use Metrilo\Analytics\Helper\Data;
+
 class CategoryData
 {
-    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
-    
+    private $chunkItems = Data::CHUNK_ITEMS;
+
+    private CollectionFactory $categoryCollection;
+
     public function __construct(
-        \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory $categoryCollection
+        CollectionFactory $categoryCollection
     ) {
         $this->categoryCollection = $categoryCollection;
     }
@@ -16,13 +21,13 @@ class CategoryData
     {
         return $this->getCategoryQuery($storeId)->setPageSize($this->chunkItems)->setCurPage($chunkId + 1);
     }
-    
+
     public function getCategoryChunks($storeId)
     {
         $totalCategories = $this->getCategoryQuery($storeId)->getSize();
         return (int) ceil($totalCategories / $this->chunkItems);
     }
-    
+
     public function getCategoryWithRequestPath($categoryId, $storeId)
     {
         return $this->categoryCollection

--- a/Model/CustomerData.php
+++ b/Model/CustomerData.php
@@ -2,50 +2,60 @@
 
 namespace Metrilo\Analytics\Model;
 
-use Metrilo\Analytics\Helper\MetriloCustomer;
+use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+use Magento\Newsletter\Model\Subscriber;
+use Metrilo\Analytics\Helper\Data;
 
 class CustomerData
 {
-    private $customerCollection;
-    private $subscriberModel;
-    private $groupRepository;
-    
-    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private CollectionFactory $customerCollection;
+
+    private Subscriber $subscriberModel;
+
+    private GroupRepositoryInterface $groupRepository;
+
+    private $chunkItems = Data::CHUNK_ITEMS;
+
+    private MetriloCustomerFactory $customerFactory;
 
     public function __construct(
-        \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory $customerCollection,
-        \Magento\Newsletter\Model\Subscriber                             $subscriberModel,
-        \Magento\Customer\Api\GroupRepositoryInterface                   $groupRepository
+        CollectionFactory $customerCollection,
+        Subscriber $subscriberModel,
+        GroupRepositoryInterface $groupRepository,
+        MetriloCustomerFactory $customerFactory
     ) {
         $this->customerCollection = $customerCollection;
-        $this->subscriberModel    = $subscriberModel;
-        $this->groupRepository    = $groupRepository;
+        $this->subscriberModel = $subscriberModel;
+        $this->groupRepository = $groupRepository;
+        $this->customerFactory = $customerFactory;
     }
 
     public function getCustomers($storeId, $chunkId)
     {
         $metriloCustomers = [];
-        $customers  = $this->getCustomerQuery($storeId)->setPageSize($this->chunkItems)->setCurPage($chunkId + 1);
-        
+        $customers = $this->getCustomerQuery($storeId)->setPageSize($this->chunkItems)->setCurPage($chunkId + 1);
+
         foreach ($customers as $customer) {
-            $metriloCustomers[] = new MetriloCustomer(
-                $customer->getStoreId(),
-                $customer->getEmail(),
-                strtotime($customer->getCreatedAt()) * 1000,
-                $customer->getData('firstname'),
-                $customer->getData('lastname'),
-                $this->getCustomerSubscriberStatus($customer->getId()),
-                $this->getCustomerGroup($customer->getGroupId())
-            );
+            $metriloCustomers[] = $this->customerFactory->create([
+                    'storeId' => $customer->getStoreId(),
+                    'email' => $customer->getEmail(),
+                    'createdAt' => strtotime($customer->getCreatedAt()) * 1000,
+                    'firstname' => $customer->getData('firstname'),
+                    'lastname' => $customer->getData('lastname'),
+                    'subscribed' => $this->getCustomerSubscriberStatus($customer->getId()),
+                    'tags' => $this->getCustomerGroup($customer->getGroupId())
+                ]);
         }
-        
+
         return $metriloCustomers;
     }
 
     public function getCustomerChunks($storeId)
     {
         $totalCustomers = $this->getCustomerQuery($storeId)->getSize();
-        return (int) ceil($totalCustomers / $this->chunkItems);
+
+        return (int)ceil($totalCustomers / $this->chunkItems);
     }
 
     private function getCustomerQuery($storeId)
@@ -56,13 +66,15 @@ class CustomerData
     private function getCustomerSubscriberStatus($customerId)
     {
         $this->subscriberModel->unsetData();
+
         return $this->subscriberModel->loadByCustomerId($customerId)->isSubscribed();
     }
 
     private function getCustomerGroup($groupId)
     {
-        $group       = $this->groupRepository->getById($groupId);
+        $group = $this->groupRepository->getById($groupId);
         $groupName[] = $group->getCode();
+
         return $groupName;
     }
 }

--- a/Model/DeletedProductData.php
+++ b/Model/DeletedProductData.php
@@ -2,32 +2,40 @@
 
 namespace Metrilo\Analytics\Model;
 
+use Magento\Framework\DB\Select;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Item\Collection;
+
 class DeletedProductData
 {
+    private CollectionFactory $orderCollection;
+
+    private Collection $orderItemCollection;
+
     public function __construct(
-        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollection,
-        \Magento\Sales\Model\ResourceModel\Order\Item\Collection   $orderItemCollection
+        CollectionFactory $orderCollection,
+        Collection $orderItemCollection
     ) {
-        $this->orderCollection     = $orderCollection;
+        $this->orderCollection = $orderCollection;
         $this->orderItemCollection = $orderItemCollection;
     }
-    
+
     public function getDeletedProductOrders($storeId)
     {
-        $deletedProductOrdersQuery = $this->orderItemCollection->getSelect()
-            ->distinct(true)
-            ->reset(\Zend_Db_Select::COLUMNS)
-            ->columns(['order_id'])
-            ->joinLeft(
-                array('catalog' => 'catalog_product_entity'),
-                'main_table.product_id = catalog.entity_id',
-                array()
-            )
-            ->where('catalog.entity_id IS NULL')
-            ->where('main_table.store_id = ?', $storeId);
-        
+        $deletedProductOrdersQuery = $this->orderItemCollection->getSelect();
+        $deletedProductOrdersQuery->distinct(true)
+                                  ->reset(Select::COLUMNS)
+                                  ->columns(['order_id'])
+                                  ->joinLeft(
+                                      ['catalog' => 'catalog_product_entity'],
+                                      'main_table.product_id = catalog.entity_id',
+                                      []
+                                  )
+                                  ->where('catalog.entity_id IS NULL')
+                                  ->where('main_table.store_id = ?', $storeId);
+
         $deletedProductOrderIds = $this->orderItemCollection->getConnection()->fetchAll($deletedProductOrdersQuery);
-        
+
         return $this->orderCollection->create()->addFieldToFilter('entity_id', ['in' => $deletedProductOrderIds]);
     }
 }

--- a/Model/Events/AddToCart.php
+++ b/Model/Events/AddToCart.php
@@ -2,17 +2,21 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\Event;
+
 class AddToCart
 {
+    private Event $event;
+
     public function __construct(
-        $event
+        Event $event
     ) {
         $this->event = $event;
     }
-    public function callJS()
+    public function callJS(): string
     {
         $item = $this->event->getQuoteItem();
-        
+
         return "window.metrilo.addToCart('" .
             $item->getProductId() . "', " .
             (int)$item->getData('qty_to_add') . ");";

--- a/Model/Events/CartView.php
+++ b/Model/Events/CartView.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Model\Events;
 
 class CartView
 {
-    public function callJS()
+    public function callJS(): string
     {
         return "window.metrilo.customEvent('view_cart');";
     }

--- a/Model/Events/CatalogSearch.php
+++ b/Model/Events/CatalogSearch.php
@@ -2,25 +2,33 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\UrlInterface;
+
 class CatalogSearch
 {
+    private UrlInterface $urlInterface;
+
+    private Http $request;
+
     public function __construct(
-        \Magento\Framework\UrlInterface     $urlInterface,
-        \Magento\Framework\App\Request\Http $request
+        UrlInterface $urlInterface,
+        Http $request
     ) {
         $this->urlInterface = $urlInterface;
-        $this->request      = $request;
+        $this->request = $request;
     }
-    public function callJS()
+
+    public function callJS(): string
     {
         $searchQuery = $this->request->getParam('q');
-        
+
         if (!empty($searchQuery)) {
             $searchText = $searchQuery;
         } else {
             $searchText = $this->request->getParam('name');
         }
-        
+
         return "window.metrilo.search('" . $searchText . "', '" . $this->urlInterface->getCurrentUrl() . "');";
     }
 }

--- a/Model/Events/CategoryView.php
+++ b/Model/Events/CategoryView.php
@@ -2,14 +2,18 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\Registry;
+
 class CategoryView
 {
+    private Registry $coreRegistry;
+
     public function __construct(
-        \Magento\Framework\Registry $registry
+        Registry $registry
     ) {
         $this->coreRegistry = $registry;
     }
-    public function callJS()
+    public function callJS(): string
     {
         return "window.metrilo.viewCategory('" .
             $this->coreRegistry->registry('current_category')->getId() . "');";

--- a/Model/Events/CheckoutView.php
+++ b/Model/Events/CheckoutView.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Model\Events;
 
 class CheckoutView
 {
-    public function callJS()
+    public function callJS(): string
     {
         return "window.metrilo.checkout();";
     }

--- a/Model/Events/CustomEvent.php
+++ b/Model/Events/CustomEvent.php
@@ -4,12 +4,14 @@ namespace Metrilo\Analytics\Model\Events;
 
 class CustomEvent
 {
+    private string $customEvent;
+
     public function __construct(
-        $customEvent
+        string $customEvent
     ) {
         $this->customEvent = $customEvent;
     }
-    public function callJS()
+    public function callJS(): string
     {
         return 'window.metrilo.customEvent("' . $this->customEvent . '");';
     }

--- a/Model/Events/IdentifyCustomer.php
+++ b/Model/Events/IdentifyCustomer.php
@@ -4,12 +4,14 @@ namespace Metrilo\Analytics\Model\Events;
 
 class IdentifyCustomer
 {
+    private string $email;
+
     public function __construct(
-        $email
+        string $email
     ) {
         $this->email = $email;
     }
-    public function callJS()
+    public function callJS(): string
     {
         return 'window.metrilo.identify("' . $this->email . '");';
     }

--- a/Model/Events/PageView.php
+++ b/Model/Events/PageView.php
@@ -2,19 +2,32 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Page\Title;
+
 class PageView
 {
+    private Title $pageTitle;
+
+    private UrlInterface $urlInterface;
+
+    private Json $json;
+
     public function __construct(
-        \Magento\Framework\View\Page\Title $pageTitle,
-        \Magento\Framework\UrlInterface    $urlInterface
+        Title $pageTitle,
+        UrlInterface $urlInterface,
+        Json $json
     ) {
-        $this->pageTitle    = $pageTitle;
+        $this->pageTitle = $pageTitle;
         $this->urlInterface = $urlInterface;
+        $this->json = $json;
     }
-    public function callJS()
+
+    public function callJS(): string
     {
         return "window.metrilo.viewPage('" .
             $this->urlInterface->getCurrentUrl() . "', " .
-            json_encode(array('name' => $this->pageTitle->getShort())) . ");";
+            $this->json->serialize(['name' => $this->pageTitle->getShort()]) . ");";
     }
 }

--- a/Model/Events/ProductView.php
+++ b/Model/Events/ProductView.php
@@ -2,15 +2,19 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\Registry;
+
 class ProductView
 {
+    private Registry $coreRegistry;
+
     public function __construct(
-        \Magento\Framework\Registry $registry
+        Registry $registry
     ) {
         $this->coreRegistry = $registry;
     }
-    
-    public function callJS()
+
+    public function callJS(): string
     {
         return "window.metrilo.viewProduct(" . $this->coreRegistry->registry('current_product')->getId() . ");";
     }

--- a/Model/Events/RemoveFromCart.php
+++ b/Model/Events/RemoveFromCart.php
@@ -2,17 +2,21 @@
 
 namespace Metrilo\Analytics\Model\Events;
 
+use Magento\Framework\Event;
+
 class RemoveFromCart
 {
+    private Event $event;
+
     public function __construct(
-        $event
+        Event $event
     ) {
         $this->event = $event;
     }
-    public function callJS()
+    public function callJS(): string
     {
         $item = $this->event->getQuoteItem();
-        
+
         return "window.metrilo.removeFromCart('" .
             $item->getProductId() . "', " .
             (int)$item->getQty() . ");";

--- a/Model/MetriloCustomer.php
+++ b/Model/MetriloCustomer.php
@@ -1,17 +1,23 @@
 <?php
 
-namespace Metrilo\Analytics\Helper;
+namespace Metrilo\Analytics\Model;
 
-class MetriloCustomer extends \Magento\Framework\App\Helper\AbstractHelper
+class MetriloCustomer
 {
     private $storeId;
+
     private $email;
+
     private $createdAt;
+
     private $firstName;
+
     private $lastName;
+
     private $subscribed;
+
     private $tags;
-    
+
     public function __construct(
         $storeId,
         $email,
@@ -21,45 +27,45 @@ class MetriloCustomer extends \Magento\Framework\App\Helper\AbstractHelper
         $subscribed,
         $tags
     ) {
-        $this->storeId    = $storeId;
-        $this->email      = $email;
-        $this->createdAt  = $createdAt;
-        $this->firstName  = $firstName;
-        $this->lastName   = $lastName;
+        $this->storeId = $storeId;
+        $this->email = $email;
+        $this->createdAt = $createdAt;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
         $this->subscribed = $subscribed;
-        $this->tags       = $tags;
+        $this->tags = $tags;
     }
-    
+
     public function getStoreId()
     {
         return $this->storeId;
     }
-    
+
     public function getEmail()
     {
         return $this->email;
     }
-    
+
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
-    
+
     public function getFirstName()
     {
         return $this->firstName;
     }
-    
+
     public function getLastName()
     {
         return $this->lastName;
     }
-    
+
     public function getSubscriberStatus()
     {
         return $this->subscribed;
     }
-    
+
     public function getTags()
     {
         return $this->tags;

--- a/Model/OrderData.php
+++ b/Model/OrderData.php
@@ -2,12 +2,17 @@
 
 namespace Metrilo\Analytics\Model;
 
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Metrilo\Analytics\Helper\Data;
+
 class OrderData
 {
-    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = Data::CHUNK_ITEMS;
+
+    private CollectionFactory $orderCollection;
 
     public function __construct(
-        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollection
+        CollectionFactory $orderCollection
     ) {
         $this->orderCollection = $orderCollection;
     }
@@ -20,14 +25,15 @@ class OrderData
     public function getOrderChunks($storeId)
     {
         $totalOrders = $this->getOrderQuery($storeId)->getSize();
-        return (int) ceil($totalOrders / $this->chunkItems);
+
+        return (int)ceil($totalOrders / $this->chunkItems);
     }
 
     private function getOrderQuery($storeId)
     {
         return $this->orderCollection->create()
-            ->addAttributeToFilter('store_id', $storeId)
-            ->addAttributeToSelect('*')
-            ->setOrder('entity_id', 'asc');
+                                     ->addAttributeToFilter('store_id', $storeId)
+                                     ->addAttributeToSelect('*')
+                                     ->setOrder('entity_id', 'asc');
     }
 }

--- a/Model/ProductData.php
+++ b/Model/ProductData.php
@@ -2,12 +2,18 @@
 
 namespace Metrilo\Analytics\Model;
 
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Metrilo\Analytics\Helper\Data;
+
 class ProductData
 {
-    private $chunkItems = \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS;
+    private $chunkItems = Data::CHUNK_ITEMS;
+
+    private CollectionFactory $productCollection;
 
     public function __construct(
-        \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollection
+        CollectionFactory $productCollection
     ) {
         $this->productCollection = $productCollection;
     }
@@ -19,13 +25,13 @@ class ProductData
                     ->setCurPage($chunkId + 1)
                     ->setDataToAll('store_id', $storeId);
     }
-    
+
     public function getProductChunks($storeId)
     {
         $totalProducts = $this->getProductQuery($storeId)->getSize();
         return (int) ceil($totalProducts / $this->chunkItems);
     }
-    
+
     public function getProductWithRequestPath($productId, $storeId)
     {
         $productObject = $this->productCollection
@@ -39,12 +45,12 @@ class ProductData
                 ['entity_id' => $productId,
                     'entity_type' => 'product',
                     'store_id' => $storeId,
-                    'metadata' => array('null' => true)]
+                    'metadata' => ['null' => true]]
             )
             ->getFirstItem();
-        
+
         $productObject->setStoreId($storeId);
-        
+
         return $productObject;
     }
 
@@ -66,7 +72,7 @@ class ProductData
                 'request_path',
                 'visibility'
             ])
-            ->addAttributeToFilter('visibility', \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->addAttributeToFilter('visibility', Visibility::VISIBILITY_BOTH)
             ->addStoreFilter($storeId);
     }
 }

--- a/Model/Trimmed.php
+++ b/Model/Trimmed.php
@@ -2,13 +2,15 @@
 
 namespace Metrilo\Analytics\Model;
 
-class Trimmed extends \Magento\Framework\App\Config\Value
+use Magento\Framework\App\Config\Value;
+
+class Trimmed extends Value
 {
     public function beforeSave()
     {
         $value = trim($this->getValue());
         $this->setValue($value);
 
-        parent::beforeSave();
+        return parent::beforeSave();
     }
 }

--- a/Observer/Category.php
+++ b/Observer/Category.php
@@ -4,45 +4,57 @@ namespace Metrilo\Analytics\Observer;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Metrilo\Analytics\Helper\ApiClient;
+use Metrilo\Analytics\Helper\CategorySerializer;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Model\CategoryData;
 
 class Category implements ObserverInterface
 {
+    private Data $helper;
+
+    private ApiClient $apiClient;
+
+    private CategorySerializer $categorySerializer;
+
+    private CategoryData $categoryData;
+
     /**
-     * @param \Metrilo\Analytics\Helper\Data               $helper
-     * @param \Metrilo\Analytics\Helper\ApiClient          $apiClient
-     * @param \Metrilo\Analytics\Helper\CategorySerializer $categorySerializer
-     * @param \Metrilo\Analytics\Model\CategoryData        $categoryData
+     * @param Data $helper
+     * @param ApiClient $apiClient
+     * @param CategorySerializer $categorySerializer
+     * @param CategoryData $categoryData
      */
     public function __construct(
-        \Metrilo\Analytics\Helper\Data               $helper,
-        \Metrilo\Analytics\Helper\ApiClient          $apiClient,
-        \Metrilo\Analytics\Helper\CategorySerializer $categorySerializer,
-        \Metrilo\Analytics\Model\CategoryData        $categoryData
+        Data $helper,
+        ApiClient $apiClient,
+        CategorySerializer $categorySerializer,
+        CategoryData $categoryData
     ) {
-        $this->helper             = $helper;
-        $this->apiClient          = $apiClient;
+        $this->helper = $helper;
+        $this->apiClient = $apiClient;
         $this->categorySerializer = $categorySerializer;
-        $this->categoryData       = $categoryData;
+        $this->categoryData = $categoryData;
     }
-    
-    public function execute(Observer $observer)
+
+    public function execute(Observer $observer): void
     {
         try {
-            $category        = $observer->getEvent()->getCategory();
+            $category = $observer->getEvent()->getCategory();
             $categoryStoreId = $category->getStoreId();
-            
+
             if ($categoryStoreId == 0) {
-                $categoryStoreIds   = $this->helper->getStoreIdsPerProject($category->getStoreIds());
+                $categoryStoreIds = $this->helper->getStoreIdsPerProject($category->getStoreIds());
             } else {
                 if (!$this->helper->isEnabled($categoryStoreId)) {
                     return;
                 }
                 $categoryStoreIds[] = $categoryStoreId;
             }
-            
+
             foreach ($categoryStoreIds as $storeId) {
                 $categoryObject = $this->categoryData->getCategoryWithRequestPath($category->getId(), $storeId);
-                $client         = $this->apiClient->getClient($storeId);
+                $client = $this->apiClient->getClient($storeId);
                 $client->category($this->categorySerializer->serialize($categoryObject));
             }
         } catch (\Exception $e) {

--- a/Observer/Config.php
+++ b/Observer/Config.php
@@ -4,25 +4,39 @@ namespace Metrilo\Analytics\Observer;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Metrilo\Analytics\Helper\Activity;
+use Metrilo\Analytics\Helper\Data;
 
 class Config implements ObserverInterface
 {
+    private ManagerInterface $messageManager;
+
+    private Data $dataHelper;
+
+    private Activity $activityHelper;
+
+    private StoreManagerInterface $storeManager;
+
     public function __construct(
-        \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Metrilo\Analytics\Helper\Data              $dataHelper,
-        \Metrilo\Analytics\Helper\Activity          $activityHelper
+        ManagerInterface $messageManager,
+        Data $dataHelper,
+        Activity $activityHelper,
+        StoreManagerInterface $storeManager
     ) {
         $this->messageManager = $messageManager;
-        $this->dataHelper     = $dataHelper;
+        $this->dataHelper = $dataHelper;
         $this->activityHelper = $activityHelper;
+        $this->storeManager = $storeManager;
     }
 
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         try {
-            $storeId = $observer->getStore();
+            $storeId = $this->getStoreId($observer);
             if (!$this->activityHelper->createActivity($storeId, 'integrated')) {
-                if ((int)$storeId === 0) {
+                if ($storeId === 0) {
                     $this->messageManager->addError(
                         'You\'ve just entered the API token and API Secret to the default configuration scope.
                         This means that the Metrilo module will be added to all your store views.
@@ -39,6 +53,17 @@ class Config implements ObserverInterface
             }
         } catch (\Exception $e) {
             $this->dataHelper->logError($e);
+        }
+    }
+
+    private function getStoreId(Observer $observer): int
+    {
+        if (!empty($observer->getStore())) {
+            return (int)$observer->getStore();
+        } elseif (!empty($observer->getWebsite())) {
+            return (int)$this->storeManager->getWebsite($observer->getWebsite())->getDefaultStore()->getId();
+        } else {
+            return 0;
         }
     }
 }

--- a/Observer/Customer.php
+++ b/Observer/Customer.php
@@ -2,166 +2,207 @@
 
 namespace Metrilo\Analytics\Observer;
 
+use Exception;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\GroupRepositoryInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Metrilo\Analytics\Helper\MetriloCustomer;
-use Metrilo\Analytics\Model\Events\IdentifyCustomer;
-use Metrilo\Analytics\Model\Events\CustomEvent;
+use Magento\Newsletter\Model\Subscriber;
+use Metrilo\Analytics\Helper\ApiClient;
+use Metrilo\Analytics\Helper\CustomerSerializer;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\SessionEvents;
+use Metrilo\Analytics\Model\Events\CustomEventFactory;
+use Metrilo\Analytics\Model\Events\IdentifyCustomerFactory;
+use Metrilo\Analytics\Model\MetriloCustomerFactory;
 
 class Customer implements ObserverInterface
 {
+    private Data $helper;
+
+    private ApiClient $apiClient;
+
+    private CustomerSerializer $customerSerializer;
+
+    private CustomerRepositoryInterface $customerRepository;
+
+    private Subscriber $subscriberModel;
+
+    private SessionEvents $sessionEvents;
+
+    private GroupRepositoryInterface $groupRepository;
+
+    private MetriloCustomerFactory $customerFactory;
+
+    private IdentifyCustomerFactory $identifyCustomerFactory;
+
+    private CustomEventFactory $customEventFactory;
+
     /**
-     * @param \Metrilo\Analytics\Helper\Data                    $helper
-     * @param \Metrilo\Analytics\Helper\ApiClient               $apiClient
-     * @param \Metrilo\Analytics\Helper\CustomerSerializer      $customerSerializer
-     * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository
-     * @param \Magento\Newsletter\Model\Subscriber              $subscriberModel
-     * @param \Magento\Customer\Api\GroupRepositoryInterface    $groupRepository
-     * @param \Metrilo\Analytics\Helper\SessionEvents           $sessionEvents
+     * @param Data $helper
+     * @param ApiClient $apiClient
+     * @param CustomerSerializer $customerSerializer
+     * @param CustomerRepositoryInterface $customerRepository
+     * @param Subscriber $subscriberModel
+     * @param GroupRepositoryInterface $groupRepository
+     * @param SessionEvents $sessionEvents
+     * @param MetriloCustomerFactory $customerFactory
+     * @param IdentifyCustomerFactory $identifyCustomerFactory
+     * @param CustomEventFactory $customEventFactory
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
-        \Metrilo\Analytics\Helper\Data                    $helper,
-        \Metrilo\Analytics\Helper\ApiClient               $apiClient,
-        \Metrilo\Analytics\Helper\CustomerSerializer      $customerSerializer,
-        \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
-        \Magento\Newsletter\Model\Subscriber              $subscriberModel,
-        \Magento\Customer\Api\GroupRepositoryInterface    $groupRepository,
-        \Metrilo\Analytics\Helper\SessionEvents           $sessionEvents
+        Data $helper,
+        ApiClient $apiClient,
+        CustomerSerializer $customerSerializer,
+        CustomerRepositoryInterface $customerRepository,
+        Subscriber $subscriberModel,
+        GroupRepositoryInterface $groupRepository,
+        SessionEvents $sessionEvents,
+        MetriloCustomerFactory $customerFactory,
+        IdentifyCustomerFactory $identifyCustomerFactory,
+        CustomEventFactory $customEventFactory
     ) {
-        $this->helper             = $helper;
-        $this->apiClient          = $apiClient;
+        $this->helper = $helper;
+        $this->apiClient = $apiClient;
         $this->customerSerializer = $customerSerializer;
         $this->customerRepository = $customerRepository;
-        $this->subscriberModel    = $subscriberModel;
-        $this->groupRepository    = $groupRepository;
-        $this->sessionEvents      = $sessionEvents;
+        $this->subscriberModel = $subscriberModel;
+        $this->groupRepository = $groupRepository;
+        $this->sessionEvents = $sessionEvents;
+        $this->customerFactory = $customerFactory;
+        $this->identifyCustomerFactory = $identifyCustomerFactory;
+        $this->customEventFactory = $customEventFactory;
     }
-    
+
     private function getCustomerFromEvent($observer)
     {
         switch ($observer->getEvent()->getName()) {
             case 'customer_save_after':
                 $customer = $observer->getEvent()->getCustomer();
                 if ($this->hasCustomerChanged($customer)) {
-                    return new MetriloCustomer(
-                        $customer->getStoreId(),
-                        $customer->getEmail(),
-                        strtotime($customer->getCreatedAt()) * 1000,
-                        $customer->getData('firstname'),
-                        $customer->getData('lastname'),
-                        $this->getCustomerSubscriberStatus($customer->getId()),
-                        $this->getCustomerGroup($customer->getGroupId())
+                    return $this->customerFactory->create(
+                        [
+                            'storeId' => $customer->getStoreId(),
+                            'email' => $customer->getEmail(),
+                            'createAt' => strtotime($customer->getCreatedAt()) * 1000,
+                            'firstName' => $customer->getData('firstname'),
+                            'lastName' => $customer->getData('lastname'),
+                            'subscribed' => $this->getCustomerSubscriberStatus($customer->getId()),
+                            'tags' => $this->getCustomerGroup($customer->getGroupId())
+                        ]
                     );
                 }
-                
                 break;
             case 'newsletter_subscriber_save_after':
                 $subscriber = $observer->getEvent()->getSubscriber();
                 $customerId = $subscriber->getCustomerId();
-                if ($subscriber->isStatusChanged() && $customerId !== 0) {
+                if ($subscriber->isStatusChanged() && !empty($customerId)) {
                     return $this->metriloCustomer($this->customerRepository->getById($customerId));
                 } else {
-                    $subscriberEmail  = $subscriber->getEmail();
-                    $identifyCustomer = new IdentifyCustomer($subscriberEmail);
-                    $customEvent      = new CustomEvent('Subscribed');
-                    
+                    $subscriberEmail = $subscriber->getEmail();
+                    $identifyCustomer = $this->identifyCustomerFactory->create(['email' => $subscriberEmail]);
+                    $customEvent = $this->customEventFactory->create(['customEvent' => 'Subscribed']);
+
                     $this->sessionEvents->addSessionEvent($identifyCustomer->callJs());
                     $this->sessionEvents->addSessionEvent($customEvent->callJs());
-                    
-                    return new MetriloCustomer(
-                        $subscriber->getStoreId(),
-                        $subscriberEmail,
-                        time() * 1000,
-                        '',
-                        '',
-                        true,
-                        ['Newsletter']
+
+                    return $this->customerFactory->create(
+                        [
+                            'storeId' => $subscriber->getStoreId(),
+                            'email' => $subscriberEmail,
+                            'createdAt' => time() * 1000,
+                            'firstName' => '',
+                            'lastName' => '',
+                            'subscribed' => true,
+                            'tags' => ['Newsletter']
+                        ]
                     );
                 }
-                
-                break;
             case 'customer_account_edited':
                 return $this->metriloCustomer($this->customerRepository->get($observer->getEvent()->getEmail()));
-                
-                break;
             case 'customer_register_success':
                 return $this->metriloCustomer($observer->getEvent()->getCustomer());
-                
-                break;
             case 'sales_order_save_after':
-                return new MetriloCustomer(
-                    $observer->getEvent()->getOrder()->getStoreId(),
-                    $observer->getEvent()->getOrder()->getCustomerEmail(),
-                    strtotime($observer->getEvent()->getOrder()->getCreatedAt()) * 1000,
-                    $observer->getEvent()->getOrder()->getBillingAddress()->getData('firstname'),
-                    $observer->getEvent()->getOrder()->getBillingAddress()->getData('lastname'),
-                    true,
-                    ['guest_customer']
+                return $this->customerFactory->create(
+                    [
+                        'storeId' => $observer->getEvent()->getOrder()->getStoreId(),
+                        'email' => $observer->getEvent()->getOrder()->getCustomerEmail(),
+                        'createdAt' => strtotime($observer->getEvent()->getOrder()->getCreatedAt()) * 1000,
+                        'firstName' => $observer->getEvent()->getOrder()->getBillingAddress()->getData('firstname'),
+                        'lastName' => $observer->getEvent()->getOrder()->getBillingAddress()->getData('lastname'),
+                        'subscribed' => true,
+                        'tags' => ['guest_customer']
+                    ]
                 );
-                
-                break;
             default:
                 break;
         }
-        
+
         return false;
     }
-    
+
     private function hasCustomerChanged($customer)
     {
         $originalCustomer = $this->customerRepository->getById($customer->getId());
-        
+
         if ($originalCustomer->getCreatedAt() === $originalCustomer->getUpdatedAt()) {
             return true; // if customer is created in admin there are no differences in $customer and $originalCustomer
         }
-        
+
         return $customer->getEmail() != $originalCustomer->getEmail() ||
-                $customer->getFirstname() != $originalCustomer->getFirstname() ||
-                $customer->getLastname() != $originalCustomer->getLastname() ||
-                $customer->getGroupId() != $originalCustomer->getGroupId();
+            $customer->getFirstname() != $originalCustomer->getFirstname() ||
+            $customer->getLastname() != $originalCustomer->getLastname() ||
+            $customer->getGroupId() != $originalCustomer->getGroupId();
     }
-    
+
     private function getCustomerSubscriberStatus($customerId)
     {
         $this->subscriberModel->unsetData();
+
         return $this->subscriberModel->loadByCustomerId($customerId)->isSubscribed();
     }
-    
+
     private function getCustomerGroup($groupId)
     {
-        $group       = $this->groupRepository->getById($groupId);
+        $group = $this->groupRepository->getById($groupId);
         $groupName[] = $group->getCode();
+
         return $groupName;
     }
-    
+
     private function metriloCustomer($customer)
     {
-        return new MetriloCustomer(
-            $customer->getStoreId(),
-            $customer->getEmail(),
-            strtotime($customer->getCreatedAt()) * 1000,
-            $customer->getFirstName(),
-            $customer->getLastName(),
-            $this->getCustomerSubscriberStatus($customer->getId()),
-            $this->getCustomerGroup($customer->getGroupId())
+        return $this->customerFactory->create(
+            [
+                'storeId' => $customer->getStoreId(),
+                'email' => $customer->getEmail(),
+                'createdAt' => strtotime($customer->getCreatedAt()) * 1000,
+                'firstName' => $customer->getFirstName(),
+                'lastName' => $customer->getLastName(),
+                'subscribed' => $this->getCustomerSubscriberStatus($customer->getId()),
+                'tags' => $this->getCustomerGroup($customer->getGroupId())
+            ]
         );
     }
-    
+
     public function execute(Observer $observer)
     {
         try {
             $customer = $this->getCustomerFromEvent($observer);
             if ($customer && $this->helper->isEnabled($customer->getStoreId())) {
                 if (!trim($customer->getEmail())) {
-                    $this->helper->logError('Customer with id = '. $customer->getId(). '  has no email address!');
+                    $this->helper
+                        ->logError('Customer with id = ' . $customer->getId() . '  has no email address!');
                     return;
                 }
-                
-                $client             = $this->apiClient->getClient($customer->getStoreId());
+
+                $client = $this->apiClient->getClient($customer->getStoreId());
                 $serializedCustomer = $this->customerSerializer->serialize($customer);
                 $client->customer($serializedCustomer);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->helper->logError($e);
         }
     }

--- a/Observer/Order.php
+++ b/Observer/Order.php
@@ -2,50 +2,55 @@
 
 namespace Metrilo\Analytics\Observer;
 
+use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Metrilo\Analytics\Helper\ApiClient;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\OrderSerializer;
 
 class Order implements ObserverInterface
 {
-    
-    private $helper;
-    
-    /**
-     * @param \Metrilo\Analytics\Helper\Data $helper
-     */
+    private Data $helper;
+
+    private ApiClient $apiClient;
+
+    private OrderSerializer $orderSerializer;
+
     public function __construct(
-        \Metrilo\Analytics\Helper\Data            $helper,
-        \Metrilo\Analytics\Helper\ApiClient       $apiClient,
-        \Metrilo\Analytics\Helper\OrderSerializer $orderSerializer
+        Data $helper,
+        ApiClient $apiClient,
+        OrderSerializer $orderSerializer
     ) {
-        $this->helper          = $helper;
-        $this->apiClient       = $apiClient;
+        $this->helper = $helper;
+        $this->apiClient = $apiClient;
         $this->orderSerializer = $orderSerializer;
     }
-    
+
     /**
      * Trigger on save Order
      *
-     * @param  \Magento\Framework\Event\Observer $observer
+     * @param Observer $observer
+     *
      * @return void
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         try {
             $order = $observer->getEvent()->getOrder();
             $storeId = $order->getStoreId();
-            
+
             if (!$this->helper->isEnabled($storeId)) {
                 return;
             }
-            
-            $client          = $this->apiClient->getClient($storeId);
+
+            $client = $this->apiClient->getClient($storeId);
             $serializedOrder = $this->orderSerializer->serialize($order);
-            
+
             if ($serializedOrder) {
                 $client->order($serializedOrder);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->helper->logError($e);
         }
     }

--- a/Observer/Product.php
+++ b/Observer/Product.php
@@ -2,55 +2,74 @@
 
 namespace Metrilo\Analytics\Observer;
 
+use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Metrilo\Analytics\Helper\ApiClient;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\ProductOptions;
+use Metrilo\Analytics\Helper\ProductSerializer;
+use Metrilo\Analytics\Model\ProductData;
 
 class Product implements ObserverInterface
 {
+    private Data $helper;
+
+    private ApiClient $apiClient;
+
+    private ProductSerializer $productSerializer;
+
+    private ProductData $productData;
+
+    private ProductOptions $productOptions;
+
     /**
-     * @param \Metrilo\Analytics\Helper\Data              $helper
-     * @param \Metrilo\Analytics\Helper\ApiClient         $apiClient
-     * @param \Metrilo\Analytics\Helper\ProductSerializer $productSerializer,
-     * @param \Metrilo\Analytics\Model\ProductData        $productData
+     * @param Data $helper
+     * @param ApiClient $apiClient
+     * @param ProductSerializer $productSerializer
+     * @param ProductData $productData
+     * @param ProductOptions $productOptions
      */
     public function __construct(
-        \Metrilo\Analytics\Helper\Data              $helper,
-        \Metrilo\Analytics\Helper\ApiClient         $apiClient,
-        \Metrilo\Analytics\Helper\ProductSerializer $productSerializer,
-        \Metrilo\Analytics\Model\ProductData        $productData
+        Data $helper,
+        ApiClient $apiClient,
+        ProductSerializer $productSerializer,
+        ProductData $productData,
+        ProductOptions $productOptions
     ) {
-        $this->helper            = $helper;
-        $this->apiClient         = $apiClient;
+        $this->helper = $helper;
+        $this->apiClient = $apiClient;
         $this->productSerializer = $productSerializer;
-        $this->productData       = $productData;
+        $this->productData = $productData;
+        $this->productOptions = $productOptions;
     }
-    
+
     public function execute(Observer $observer)
     {
         try {
-            $product        = $observer->getEvent()->getProduct();
+            $product = $observer->getEvent()->getProduct();
             $productStoreId = $product->getStoreId();
-            
+
             if ($productStoreId == 0) {
-                $productStoreIds   = $this->helper->getStoreIdsPerProject($product->getStoreIds());
+                $productStoreIds = $this->helper->getStoreIdsPerProject($product->getStoreIds());
             } else {
                 if (!$this->helper->isEnabled($productStoreId)) {
                     return;
                 }
                 $productStoreIds[] = $productStoreId;
             }
-            
+
             foreach ($productStoreIds as $storeId) {
-                $client         = $this->apiClient->getClient($storeId);
-                $productParents = $this->productSerializer->productOptions->getParentIds($product->getId(), $product->getTypeId());
-                $productsToSync = ($productParents) ? $productParents : [$product->getId()];
-                
+                $client = $this->apiClient->getClient($storeId);
+                $productParents = $this->productOptions->getParentIds($product->getId(), $product->getTypeId());
+                $productsToSync = ($productParents) ?: [$product->getId()];
+
                 foreach ($productsToSync as $productId) {
                     $productWithRequestPath = $this->productData->getProductWithRequestPath($productId, $storeId);
                     $client->product($this->productSerializer->serialize($productWithRequestPath));
                 }
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->helper->logError($e);
         }
     }

--- a/Observer/RemoveFromCart.php
+++ b/Observer/RemoveFromCart.php
@@ -4,26 +4,35 @@ namespace Metrilo\Analytics\Observer;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Metrilo\Analytics\Model\Events\RemoveFromCart as RemoveFromCartEvent;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Helper\SessionEvents;
+use Metrilo\Analytics\Model\Events\RemoveFromCartFactory;
 
 class RemoveFromCart implements ObserverInterface
 {
-    
+    private Data $helper;
+
+    private SessionEvents $sessionEvents;
+
+    private RemoveFromCartFactory $removeFromCartFactory;
+
     public function __construct(
-        \Metrilo\Analytics\Helper\Data          $helper,
-        \Metrilo\Analytics\Helper\SessionEvents $sessionEvents
+        Data $helper,
+        SessionEvents $sessionEvents,
+        RemoveFromCartFactory $removeFromCartFactory
     ) {
-        $this->helper        = $helper;
+        $this->helper = $helper;
         $this->sessionEvents = $sessionEvents;
+        $this->removeFromCartFactory = $removeFromCartFactory;
     }
-    
+
     public function execute(Observer $observer)
     {
         try {
             if (!$this->helper->isEnabled($observer->getEvent()->getQuoteItem()->getStoreId())) {
                 return;
             }
-            $removeFromCartEvent = new RemoveFromCartEvent($observer->getEvent());
+            $removeFromCartEvent = $this->removeFromCartFactory->create(['event' => $observer->getEvent()]);
             $this->sessionEvents->addSessionEvent($removeFromCartEvent->callJs());
         } catch (\Exception $e) {
             $this->helper->logError($e);

--- a/Test/Unit/Api/ClientTest.php
+++ b/Test/Unit/Api/ClientTest.php
@@ -2,17 +2,21 @@
 
 namespace Metrilo\Analytics\Test\Unit\Api;
 
-use \Metrilo\Analytics\Api\Validator;
-use \Metrilo\Analytics\Api\Connection;
-use \Metrilo\Analytics\Api\Client;
+use Metrilo\Analytics\Api\Client;
+use Metrilo\Analytics\Api\Connection;
+use Metrilo\Analytics\Api\ConnectionFactory;
+use Metrilo\Analytics\Api\Validator;
+use Metrilo\Analytics\Api\ValidatorFactory;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit\Framework\TestCase
+class ClientTest extends TestCase
 {
-    private $logPath = BP . '/var/log';
-    private $validator;
-    private $connection;
-    private $client;
-    
+    private Validator $validator;
+
+    private Connection $connection;
+
+    private Client $client;
+
     public function setup(): void
     {
         $this->validator = $this->getMockBuilder(Validator::class)
@@ -28,22 +32,37 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 'validateOrders',
                 'createActivity'])
             ->getMock();
-    
+
         $this->connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods(['post'])
             ->getMock();
-        
+
+        $validatorFactory = $this->getMockBuilder(ValidatorFactory::class)
+                                 ->disableOriginalConstructor()
+                                 ->getMock();
+        $validatorFactory->expects($this->once())
+                         ->method('create')
+                         ->will($this->returnValue($this->validator));
+
+        $connectionFactory = $this->getMockBuilder(ConnectionFactory::class)
+                                  ->disableOriginalConstructor()
+                                  ->getMock();
+        $connectionFactory->expects($this->once())
+                          ->method('create')
+                          ->will($this->returnValue($this->connection));
+
         $this->client = new Client(
             'project_token',
             'project_secret',
             'Magento 2.3.0',
             '2.0.0',
             'https://trk.mtrl.me',
-            $this->logPath
+            $validatorFactory,
+            $connectionFactory
         );
     }
-    
+
     public function testCustomer()
     {
         $serializedCustomer = [
@@ -54,21 +73,25 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => ['customer_group']
         ];
-        
+
         $this->validator->expects($this->any())->method('validateCustomer')
             ->with($this->equalTo($serializedCustomer))
             ->will($this->returnValue(true));
-        
+
         $expected = [
             'response' => '',
             'code'     => 401
         ];
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->customer($serializedCustomer);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testCustomerBatch()
     {
         $serializedCustomers[] = [
@@ -79,7 +102,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => false,
             'tags'        => ['customers_group']
         ];
-    
+
         $serializedCustomers[] = [
             'email'       => 'subscriber@email.com',
             'createdAt'   => 1518004715739,
@@ -88,21 +111,25 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => ['subscriber_group']
         ];
-        
+
         $this->validator->expects($this->any())->method('validateCustomers')
             ->with($this->equalTo($serializedCustomers))
             ->will($this->returnValue($serializedCustomers));
-        
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->customerBatch($serializedCustomers);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testCategory()
     {
         $category = [
@@ -110,21 +137,25 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'name' => 'categoryName',
             'url'  => 'https://base/url/string/request/path.html'
         ];
-        
+
         $this->validator->expects($this->any())->method('validateCategory')
             ->with($this->equalTo($category))
             ->will($this->returnValue(true));
-    
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-    
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->category($category);
-    
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testCategoryBatch()
     {
         $categories[] = [
@@ -132,27 +163,31 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'name' => 'firstCategoryName',
             'url'  => 'https://base/url/string/request/path/firstCat.html'
         ];
-    
+
         $categories[] = [
             'id'   => '1235',
             'name' => 'secondCategoryName',
             'url'  => 'https://base/url/string/request/path/secondCat.html'
         ];
-        
+
         $this->validator->expects($this->any())->method('validateCategories')
             ->with($this->equalTo($categories))
             ->will($this->returnValue($categories));
-        
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->categoryBatch($categories);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testProduct()
     {
         $productOptions[] = [
@@ -162,7 +197,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 'price'    => 123,
                 'imageUrl' => 'https://base/url/string/catalog/product/product/image/url.jpg'
         ];
-        
+
         $product = [
             'categories' => ['1', '2'],
             'id'         => '1',
@@ -173,21 +208,25 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'url'        => 'https://base/url/string/product/request/path.html',
             'options'    => $productOptions
         ];
-        
+
         $this->validator->expects($this->any())->method('validateProduct')
             ->with($this->equalTo($product))
             ->will($this->returnValue(true));
-    
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-    
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->product($product);
-    
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testProductBatch()
     {
         $firstProductOptions[] = [
@@ -197,7 +236,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'price'    => 123,
             'imageUrl' => 'https://base/url/string/catalog/product/image/firstProductOption.jpg'
         ];
-        
+
         $products[] = [
             'categories' => ['11', '22'],
             'id'         => '11',
@@ -208,7 +247,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'url'        => 'https://base/url/string/product/request/firstProduct.html',
             'options'    => $firstProductOptions
         ];
-        
+
         $products[] = [
             'categories' => ['33', '44'],
             'id'         => '6',
@@ -219,28 +258,32 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'url'        => 'https://base/url/string/product/request/secondProduct.html',
             'options'    => []
         ];
-        
+
         $this->validator->expects($this->any())->method('validateProducts')
             ->with($this->equalTo($products))
             ->will($this->returnValue($products));
-        
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->productBatch($products);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testOrder()
     {
         $orderProducts[] = [
             'productId'  => 'productSku',
             'quantity'   => 1
         ];
-        
+
         $orderBilling = [
             "firstName"     => 'firstName',
             "lastName"      => 'lastName',
@@ -251,7 +294,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             "postcode"      => '1000',
             "paymentMethod" => 'Bank Transfer'
         ];
-        
+
         $order = [
             'id'        => '111',
             'createdAt' => 1518004715749,
@@ -262,28 +305,32 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'products'  => $orderProducts,
             'billing'   => $orderBilling
         ];
-        
+
         $this->validator->expects($this->any())->method('validateOrder')
             ->with($this->equalTo($order))
             ->will($this->returnValue(true));
-    
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-    
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->order($order);
-    
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testOrderBatch()
     {
         $orderProducts[] = [
             'productId'  => 'productSku',
             'quantity'   => 1
         ];
-        
+
         $orderBilling = [
             "firstName"     => 'firstName',
             "lastName"      => 'lastName',
@@ -294,7 +341,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             "postcode"      => '1000',
             "paymentMethod" => 'Bank Transfer'
         ];
-        
+
         $orders[] = [
             'id'        => '222',
             'createdAt' => 1518004715747,
@@ -305,7 +352,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'products'  => $orderProducts,
             'billing'   => $orderBilling
         ];
-    
+
         $orders[] = [
             'id'        => '333',
             'createdAt' => 1518004715748,
@@ -316,36 +363,44 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'products'  => $orderProducts,
             'billing'   => $orderBilling
         ];
-        
+
         $this->validator->expects($this->any())->method('validateOrders')
             ->with($this->equalTo($orders))
             ->will($this->returnValue($orders));
-        
+
         $expected = [
             'response' => 'Invalid token!',
             'code'     => 401
         ];
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue($expected));
+
         $result = $this->client->orderBatch($orders);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testActivity()
     {
         $token    = 'project_token';
         $secret   = 'project_secret';
         $endPoint = 'https://p.metrilo.com';
-        
+
         $data = [
             'type'   => 'activity_type',
             'secret' => 'project_secret'
         ];
-        
+
         $url = $endPoint . '/tracking/' . $token . '/activity';
-        
+
+        $this->connection->expects($this->once())
+                         ->method('post')
+                         ->will($this->returnValue(['code' => 200]));
+
         $result = $this->client->createActivity($url, $data, $secret);
-        
-        $this->assertFalse($result);
+
+        $this->assertTrue($result);
     }
 }

--- a/Test/Unit/Api/ConnectionTest.php
+++ b/Test/Unit/Api/ConnectionTest.php
@@ -2,60 +2,126 @@
 
 namespace Metrilo\Analytics\Test\Unit\Api;
 
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Framework\Serialize\Serializer\Json;
 use Metrilo\Analytics\Api\Connection;
+use PHPUnit\Framework\TestCase;
 
-class ConnectionTest extends \PHPUnit\Framework\TestCase
+class ConnectionTest extends TestCase
 {
-    /**
-     * @var \Magento\Backend\App\Action\Context
-     */
-    private $connection;
-    
-    private $response = [
-            'response' => 'responseObject',
-            'code'     => 'responseCode'
-        ];
-    private $url = 'https://trk.mtrl.me';
-    private $bodyArray = ['data' => 'value', 'secret' => '82535e6593b51afed58e0a5a'];
-    
+    private Connection $connection;
+
+    private string $url = 'https://trk.mtrl.me/api';
+
+    private array $bodyArray = ['data' => 'value', 'secret' => '82535e6593b51afed58e0a5a'];
+
+    private Curl $curl;
+
+    private Json $json;
+
     public function setUp(): void
     {
-        $this->connection = new Connection();
+        $connectionFactory = $this->getMockBuilder(CurlFactory::class)
+                                  ->disableOriginalConstructor()
+                                  ->getMock();
+
+        $this->curl = $this->getMockBuilder(Curl::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+        $connectionFactory->expects($this->once())
+                          ->method('create')
+                          ->will($this->returnValue($this->curl));
+
+        $this->json = $this->getMockBuilder(Json::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $this->connection = new Connection($connectionFactory, $this->json);
     }
-    
+
     public function testPostWithHmacAuth()
     {
-        $this->response = [
-            'response' => '',
-            'code'     => 404
+        $response = [
+            'response' => '{"result":"success"}',
+            'code' => 200
         ];
 
-        $result = $this->connection->post($this->url, $this->bodyArray, true);
+        $encodedBody = json_encode($this->bodyArray);
+        $this->json->expects($this->once())
+                   ->method('serialize')
+                   ->with($this->bodyArray)
+                   ->will($this->returnValue($encodedBody));
+        $hmac = hash_hmac('sha256', $encodedBody, '82535e6593b51afed58e0a5a');
 
-        $this->assertEquals($this->response, $result);
+        $this->curl->expects($this->once())
+                   ->method('setOptions')
+                   ->with($this->isType('array'));
+
+        $this->curl->expects($this->exactly(6))
+                   ->method('addHeader')
+                   ->withConsecutive(
+                       ['Content-Type', 'application/json'],
+                       ['Accept', '*/*'],
+                       ['User-Agent', 'HttpClient/1.0.0'],
+                       ['Connection', 'Close'],
+                       ['Host', 'trk.mtrl.me'],
+                       ['X-Digest', $hmac],
+                   );
+
+        $this->curl->expects($this->once())
+                   ->method('post')
+                   ->with($this->url, $encodedBody);
+
+        $this->curl->expects($this->once())->method('getBody')
+                   ->will($this->returnValue('{"result":"success"}'));
+
+        $this->curl->expects($this->once())->method('getStatus')
+                   ->will($this->returnValue(200));
+
+        $result = $this->connection->post($this->url, $this->bodyArray, '82535e6593b51afed58e0a5a');
+
+        $this->assertEquals($response, $result);
     }
-    
-    public function testPostWithoutHmacAuth()
+
+    public function testPostWithoutBodyArray()
     {
-        $this->response = [
-            'response' => '',
-            'code'     => 404
+        $response = [
+            'response' => '{"result":"success"}',
+            'code' => 200
         ];
-        
-        $result = $this->connection->post($this->url, $this->bodyArray, false);
-        
-        $this->assertEquals($this->response, $result);
-    }
-    
-    public function testPostWithBodyArray()
-    {
-        $this->response = [
-            'response' => '',
-            'code'     => 404
-        ];
-    
-        $result = $this->connection->post($this->url, false, false);
-    
-        $this->assertEquals($this->response, $result);
+
+        $this->json->expects($this->once())
+                   ->method('serialize')
+                   ->with(null)
+                   ->will($this->throwException(new \InvalidArgumentException));
+
+        $this->curl->expects($this->once())
+                   ->method('setOptions')
+                   ->with($this->isType('array'));
+
+        $this->curl->expects($this->exactly(5))
+                   ->method('addHeader')
+                   ->withConsecutive(
+                       ['Content-Type', 'application/json'],
+                       ['Accept', '*/*'],
+                       ['User-Agent', 'HttpClient/1.0.0'],
+                       ['Connection', 'Close'],
+                       ['Host', 'trk.mtrl.me'],
+                   );
+
+        $this->curl->expects($this->once())
+                   ->method('post')
+                   ->with($this->url, '');
+
+        $this->curl->expects($this->once())->method('getBody')
+                   ->will($this->returnValue('{"result":"success"}'));
+
+        $this->curl->expects($this->once())->method('getStatus')
+                   ->will($this->returnValue(200));
+
+        $result = $this->connection->post($this->url, null, '82535e6593b51afed58e0a5a');
+
+        $this->assertEquals($response, $result);
     }
 }

--- a/Test/Unit/Api/ValidatorTest.php
+++ b/Test/Unit/Api/ValidatorTest.php
@@ -2,25 +2,25 @@
 
 namespace Metrilo\Analytics\Test\Unit\Api;
 
+use Magento\Framework\Logger\Monolog;
 use Metrilo\Analytics\Api\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit\Framework\TestCase
+class ValidatorTest extends TestCase
 {
-    private $logPath = BP . '/var/log';
-    private $logFile = BP . '/var/log/MetriloApiValidationErrors.log';
-    private $validator;
-    
+    private Validator $validator;
+
     public function setUp(): void
     {
-        $this->validator = new Validator($this->logPath);
+        $logger = $this->getMockBuilder(Monolog::class)
+                       ->disableOriginalConstructor()
+                       ->setMethods(['error'])
+                       ->getMock();
+        $this->validator = new Validator($logger);
     }
-    
+
     public function testValidateCustomer()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-        
         $customer = [
             'email'       => 'customer@email.com',
             'createdAt'   => 1278312378,
@@ -29,16 +29,12 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => 'customerGroup'
         ];
-        
+
         $this->assertTrue($this->validator->validateCustomer($customer));
     }
-    
+
     public function testValidateCustomers()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-        
         $customers[] = [
             'email'       => 'customer@email.com',
             'createdAt'   => 1278312378,
@@ -47,7 +43,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => 'customerGroup'
         ];
-    
+
         $customers[] = [
             'email'       => 'customer2email.com',
             'createdAt'   => '1278312378',
@@ -56,62 +52,48 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => 'customerGroup'
         ];
-        
+
         $result = $this->validator->validateCustomers($customers);
-        
+
         $this->assertEquals(1, count($result));
-        $this->assertTrue(file_exists($this->logFile));
     }
-    
+
     public function testValidateCategory()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-        
         $category = [
             'id'   => '123',
             'name' => 'categoryName',
             'url'  => 'base/url/string/url/request/path'
         ];
-    
+
         $this->assertTrue($this->validator->validateCategory($category));
     }
-    
+
     public function testValidateCategories()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-    
         $categories[] = [
             'id'   => '123',
             'name' => 'categoryName',
             'url'  => 'base/url/string/url/request/path'
         ];
-    
+
         $categories[] = [
             'id'   => 1223,
             'name' => 'categoryName',
             'url'  => 'base/url/string/url/request/path'
         ];
-    
+
         $result = $this->validator->validateCategories($categories);
-    
+
         $this->assertEquals(1, count($result));
-        $this->assertTrue(file_exists($this->logFile));
     }
-    
+
     public function testValidateProduct()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-    
         $baseUrl        = 'base/url/string/';
         $imageUrl       = '/product/image/url.jpg';
         $requestPath    = 'product/request/path.html';
-    
+
         $productOptions[] = [
             'id'       => 'productSku',
             'sku'      => 'productSku',
@@ -119,7 +101,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'price'    => '120',
             'imageUrl' => 'base/url/string/catalog/product/product/image/url.jpg'
         ];
-        
+
         $product = [
             'categories' => ['1', '3', '4'],
             'id'         => '1',
@@ -130,22 +112,16 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'url'        => $baseUrl . $requestPath,
             'options'    => $productOptions
         ];
-    
+
         $this->assertTrue($this->validator->validateProduct($product));
     }
-    
+
     public function testValidateProducts()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-        
         $baseUrl        = 'base/url/string/';
         $imageUrl       = '/product/image/url.jpg';
         $requestPath    = 'product/request/path.html';
-        
-        $productOptions = [];
-        
+
         $products[] = [
             'categories' => ['1', '3', '4'],
             'id'         => '1',
@@ -154,15 +130,15 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'name'       => 'productName',
             'price'      => 0,
             'url'        => $baseUrl . $requestPath,
-            'options'    => array([
+            'options'    => [[
                 'id'       => 'optionSku',
                 'sku'      => 'optionSku',
                 'name'     => 'optionName',
                 'price'    => '120',
                 'imageUrl' => 'base/url/string/catalog/product/product/image/url.jpg'
-                ])
+                ]]
             ];
-    
+
         $products[] = [
             'categories' => ['2', '6'],
             'id'         => '12',
@@ -173,7 +149,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'url'        => $baseUrl . $requestPath,
             'options'    => []
             ];
-    
+
         $products[] = [
             'categories' => [],
             'id'         => 123,
@@ -184,7 +160,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'url'        => $baseUrl . $requestPath,
             'options'    => []
         ];
-    
+
         $products[] = [
             'categories' => [],
             'id'         => 1234,
@@ -193,32 +169,27 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'name'       => 'failProductName',
             'price'      => 0,
             'url'        => $baseUrl . $requestPath,
-            'options'    => array([
+            'options'    => [[
                 'id'       => 'failOptionSku',
                 'sku'      => 'failOptionSku',
                 'name'     => 'failOptionName',
                 'price'    => '130',
                 'imageUrl' => 'base/url/string/catalog/product/product/image/url.jpg'
-            ])
+            ]]
         ];
-    
+
         $result = $this->validator->validateProducts($products);
-    
+
         $this->assertEquals(2, count($result));
-        $this->assertTrue(file_exists($this->logFile));
     }
-    
+
     public function validateOrder()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-    
         $orderProducts[] = [
             'productId'  => 'itemSku',
             'quantity'   => 3
         ];
-    
+
         $orderBilling = [
             "firstName"     => 'orderFirstName',
             "lastName"      => 'orderLastName',
@@ -229,7 +200,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             "postcode"      => 'postCode',
             "paymentMethod" => 'paymentMethodName'
         ];
-    
+
         $order = [
             'id'        => 1000000001,
             'createdAt' => 18296312,
@@ -240,16 +211,12 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'products'  => $orderProducts,
             'billing'   => $orderBilling
         ];
-    
+
         $this->assertTrue($this->validator->validateOrder($order));
     }
-    
+
     public function validateOrders()
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
-        }
-    
         $orders[] = [
             'id'        => 1000000001,
             'createdAt' => 18296312,
@@ -257,10 +224,10 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'amount'    => 1001,
             'coupons'   => ['couponCode'],
             'status'    => 'orderStatus',
-            'products'  => array([
+            'products'  => [[
                 'productId'  => 'itemSku',
                 'quantity'   => 3
-            ]),
+            ]],
             'billing'   => [
                 "firstName"     => 'orderFirstName',
                 "lastName"      => 'orderLastName',
@@ -272,7 +239,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                 "paymentMethod" => 'paymentMethodName'
             ]
         ];
-    
+
         $orders[] = [
             'id'        => 1000000002,
             'createdAt' => 155943172,
@@ -292,7 +259,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                 "paymentMethod" => 'secondOrderPaymentMethodName'
             ]
         ];
-    
+
         $orders[] = [
             'id'        => 1000000003,
             'createdAt' => 18296234,
@@ -300,7 +267,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'amount'    => 201,
             'coupons'   => [],
             'status'    => 'thirdOrderStatus',
-            'products'  => array(
+            'products'  => [
                 [
                     'productId'  => 'optionItemSku',
                     'quantity'   => 3
@@ -308,7 +275,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                     'productId'  => 'secondOptionItemSku',
                     'quantity'   => 1
                 ]
-            ),
+            ],
             'billing'   => [
                 "firstName"     => 'thirdOrderFirstName',
                 "lastName"      => 'thirdOrderLastName',
@@ -320,7 +287,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                 "paymentMethod" => 'thirdOrderPaymentMethodName'
             ]
         ];
-    
+
         $orders[] = [
             'id'        => 1000000004,
             'createdAt' => 155949928,
@@ -340,10 +307,9 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                 "paymentMethod" => 'lastOrderPaymentMethodName'
             ]
         ];
-    
+
         $result = $this->validator->validateOrders($orders);
-    
+
         $this->assertEquals(2, count($result));
-        $this->assertTrue(file_exists($this->logFile));
     }
 }

--- a/Test/Unit/Block/AnalyticsTest.php
+++ b/Test/Unit/Block/AnalyticsTest.php
@@ -2,9 +2,9 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\View\Element\Template\Context;
-use Magento\Framework\App\Action\Context as ActionContext;
-use Magento\Paypal\Model\Cart;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\SessionEvents;
 use Metrilo\Analytics\Model\Events\ProductView;
@@ -14,118 +14,81 @@ use Metrilo\Analytics\Model\Events\CatalogSearch;
 use Metrilo\Analytics\Model\Events\CartView;
 use Metrilo\Analytics\Model\Events\CheckoutView;
 use Metrilo\Analytics\Block\Analytics;
+use PHPUnit\Framework\TestCase;
 
-class AnalyticsTest extends \PHPUnit\Framework\TestCase
+class AnalyticsTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\View\Element\Template\Context
-     */
-    private $context;
-    
-    /**
-     * @var \Magento\Framework\App\Action\Context
-     */
-    private $actionContext;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEventsHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\ProductView
-     */
-    private $productViewEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\PageView
-     */
-    private $pageViewEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\CategoryView
-     */
-    private $categoryViewEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\CatalogSearch
-     */
-    private $catalogSearchEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\CartView
-     */
-    private $cartViewEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\ProductView
-     */
-    private $checkoutViewEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Block\Analytics
-     */
-    private $analyticsBlock;
-    
+    private RequestInterface $request;
+
+    private Data $dataHelper;
+
+    private SessionEvents $sessionEventsHelper;
+
+    private ProductView $productViewEvent;
+
+    private PageView $pageViewEvent;
+
+    private CategoryView $categoryViewEvent;
+
+    private CatalogSearch $catalogSearchEvent;
+
+    private CartView $cartViewEvent;
+
+    private CheckoutView $checkoutViewEvent;
+
+    private Analytics $analyticsBlock;
+
     public function setUp(): void
     {
-        $this->context = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        
-        $this->actionContext = $this->getMockBuilder(ActionContext::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getRequest', 'getFullActionName'])
-            ->getMock();
-        
-        $this->actionContext->expects($this->any())->method('getRequest')->will($this->returnSelf());
-        
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $this->request = $this->getMockBuilder(Http::class)
+                              ->disableOriginalConstructor()->getMock();
+
+        $context->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getApiEndpoint', 'getApiToken', 'getStoreId', 'isEnabled'])
-            ->getMock();
-        
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['getApiEndpoint', 'getApiToken', 'getStoreId', 'isEnabled'])
+                                 ->getMock();
+
         $this->sessionEventsHelper = $this->getMockBuilder(SessionEvents::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getSessionEvents'])
-            ->getMock();
-        
+                                          ->disableOriginalConstructor()
+                                          ->setMethods(['getSessionEvents'])
+                                          ->getMock();
+
         $this->productViewEvent = $this->getMockBuilder(ProductView::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                       ->disableOriginalConstructor()
+                                       ->setMethods(['callJs'])
+                                       ->getMock();
+
         $this->pageViewEvent = $this->getMockBuilder(PageView::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                    ->disableOriginalConstructor()
+                                    ->setMethods(['callJs'])
+                                    ->getMock();
+
         $this->categoryViewEvent = $this->getMockBuilder(CategoryView::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                        ->disableOriginalConstructor()
+                                        ->setMethods(['callJs'])
+                                        ->getMock();
+
         $this->catalogSearchEvent = $this->getMockBuilder(CatalogSearch::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods(['callJs'])
+                                         ->getMock();
+
         $this->cartViewEvent = $this->getMockBuilder(CartView::class)
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                    ->setMethods(['callJs'])
+                                    ->getMock();
+
         $this->checkoutViewEvent = $this->getMockBuilder(CheckoutView::class)
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                        ->setMethods(['callJs'])
+                                        ->getMock();
+
         $this->analyticsBlock = new Analytics(
-            $this->context,
-            $this->actionContext,
+            $context,
             $this->dataHelper,
             $this->sessionEventsHelper,
             $this->productViewEvent,
@@ -136,138 +99,140 @@ class AnalyticsTest extends \PHPUnit\Framework\TestCase
             $this->checkoutViewEvent
         );
     }
-    
+
     public function testGetLibraryUrl()
     {
         $apiEndpoint = 'https://trk.mtrl.me';
-        $apiToken    = '9b4dd74a736d9d7d';
-        $storeId     = 1;
-        
+        $apiToken = '9b4dd74a736d9d7d';
+        $storeId = 1;
+
         $this->dataHelper->expects($this->any())->method('getApiEndpoint')
-            ->will($this->returnValue($apiEndpoint));
+                         ->will($this->returnValue($apiEndpoint));
         $this->dataHelper->expects($this->any())->method('getApiToken')
-            ->with($this->equalTo($storeId))->will($this->returnValue($apiToken));
+                         ->with($this->equalTo($storeId))->will($this->returnValue($apiToken));
         $this->dataHelper->expects($this->any())->method('getStoreId')
-            ->will($this->returnValue($storeId));
-    
+                         ->will($this->returnValue($storeId));
+
         $expected = $apiEndpoint . '/tracking.js?token=' . $apiToken;
-        $result   = $this->analyticsBlock->getLibraryUrl();
-        
+        $result = $this->analyticsBlock->getLibraryUrl();
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testGetEventProductView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('catalog_product_view'));
-        
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('catalog_product_view'));
+
         $this->productViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
-        
-        $this->assertInstanceOf(ProductView::class, $this->analyticsBlock->getEvent());
+                               ->will($this->returnValue('zzzzProductView'));
+
+        $this->assertEquals('zzzzProductView', $this->analyticsBlock->getEvent());
     }
-    
+
     public function testGetEventCategoryView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('catalog_category_view'));
-    
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('catalog_category_view'));
         $this->categoryViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                                ->will($this->returnValue('zzzzCategoryView'));
 
-        $this->assertInstanceOf(CategoryView::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzzCategoryView', $this->analyticsBlock->getEvent());
     }
 
     public function testGetEventCatalogSearchView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('catalogsearch_result_index'));
-
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('catalogsearch_result_index'));
         $this->catalogSearchEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                                 ->will($this->returnValue('zzzzCatalogSearch'));
 
-        $this->assertInstanceOf(CatalogSearch::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzzCatalogSearch', $this->analyticsBlock->getEvent());
     }
 
     public function testGetEventCatalogAdvancedSearchView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('catalogsearch_advanced_result'));
-
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('catalogsearch_advanced_result'));
         $this->catalogSearchEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                                 ->will($this->returnValue('zzzzAdvancedSearch'));
 
-        $this->assertInstanceOf(CatalogSearch::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzzAdvancedSearch', $this->analyticsBlock->getEvent());
     }
 
     public function testGetEventCartView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('checkout_cart_index'));
-
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('checkout_cart_index'));
         $this->cartViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                            ->will($this->returnValue('zzzzCart'));
 
-        $this->assertInstanceOf(CartView::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzzCart', $this->analyticsBlock->getEvent());
     }
 
     public function testGetEventCheckoutView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue('checkout_index_index'));
-
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue('checkout_index_index'));
         $this->checkoutViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                                ->will($this->returnValue('zzzz'));
 
-        $this->assertInstanceOf(CheckoutView::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzz', $this->analyticsBlock->getEvent());
     }
 
     public function testGetEventPageView()
     {
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue(''));
-
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue(''));
         $this->pageViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnSelf());
+                            ->will($this->returnValue('zzzz'));
 
-        $this->assertInstanceOf(PageView::class, $this->analyticsBlock->getEvent());
+        $this->assertEquals('zzzz', $this->analyticsBlock->getEvent());
     }
-    
+
     public function testGetEventsWithSessionEvent()
     {
         $pageViewEvent = "window.metrilo.viewProduct(1);";
-        
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue(''));
-        
+
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue(''));
         $this->pageViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnValue($pageViewEvent));
-    
+                            ->will($this->returnValue($pageViewEvent));
+
         $this->sessionEventsHelper->expects($this->any())->method('getSessionEvents')
-            ->will($this->returnValue(['sessionEvent']));
-    
-        $expected   = ['sessionEvent'];
+                                  ->will($this->returnValue(['sessionEvent']));
+
+        $expected = ['sessionEvent'];
         $expected[] = $pageViewEvent;
 
         $this->assertSame($expected, $this->analyticsBlock->getEvents());
     }
-    
+
     public function testGetEventsWithoutSessionEvent()
     {
         $pageViewEvent = "window.metrilo.viewProduct(1);";
-        
-        $this->actionContext->expects($this->any())->method('getFullActionName')
-            ->will($this->returnValue(''));
-        
+
+        $this->request->expects($this->once())
+                      ->method('getFullActionName')
+                      ->will($this->returnValue(''));
+
         $this->pageViewEvent->expects($this->any())->method('callJs')
-            ->will($this->returnValue($pageViewEvent));
-        
+                            ->will($this->returnValue($pageViewEvent));
+
         $this->sessionEventsHelper->expects($this->any())->method('getSessionEvents')
-            ->will($this->returnValue(null));
-        
-        $expected   = null;
+                                  ->will($this->returnValue(null));
+
+        $expected = null;
         $expected[] = $pageViewEvent;
-        
+
         $this->assertSame($expected, $this->analyticsBlock->getEvents());
     }
 }

--- a/Test/Unit/Block/ImportTest.php
+++ b/Test/Unit/Block/ImportTest.php
@@ -2,51 +2,48 @@
 
 namespace Metrilo\Analytics\Test\Unit\Block;
 
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\App\Request\Http;
 use Metrilo\Analytics\Block\System\Config\Button\Import;
+use Metrilo\Analytics\Helper\Data;
+use Metrilo\Analytics\Model\CategoryData;
+use Metrilo\Analytics\Model\CustomerData;
+use Metrilo\Analytics\Model\OrderData;
+use Metrilo\Analytics\Model\ProductData;
+use PHPUnit\Framework\TestCase;
 
-class ImportTest extends \PHPUnit\Framework\TestCase
+class ImportTest extends TestCase
 {
-    /**
-     * @var Metrilo\Analytics\Block\Sysetm\Config\Button\Import
-     */
-    private $block;
+    private Import $block;
+    private Context $context;
 
-    /**
-     * @var ObjectManager
-     */
-    private $objectManager;
+    private Data $helper;
 
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Catalog\Model\ProductFactory
-     */
+    private CustomerData $customerData;
+    private CategoryData $categoryData;
 
-    private $productFactory;
+    private ProductData $productData;
 
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Catalog\Model\Product
-     */
-    private $product;
+    private OrderData $orderData;
 
-    /**
-     * @var \Rbj\ProductUnitTest\Model\ProductCollection
-     */
-    private $productCollection;
+    private Http $request;
 
     public function setUp(): void
     {
-        $this->context = $this->createMock(\Magento\Backend\Block\Template\Context::class);
+        $this->context = $this->createMock(Context::class);
 
-        $this->helper = $this->createMock(\Metrilo\Analytics\Helper\Data::class);
+        $this->helper = $this->createMock(Data::class);
 
-        $this->customerData = $this->createMock(\Metrilo\Analytics\Model\CustomerData::class);
+        $this->customerData = $this->createMock(CustomerData::class);
 
-        $this->categoryData = $this->createMock(\Metrilo\Analytics\Model\CategoryData::class);
+        $this->categoryData = $this->createMock(CategoryData::class);
 
-        $this->productData = $this->createMock(\Metrilo\Analytics\Model\ProductData::class);
+        $this->productData = $this->createMock(ProductData::class);
 
-        $this->orderData = $this->createMock(\Metrilo\Analytics\Model\OrderData::class);
+        $this->orderData = $this->createMock(OrderData::class);
 
-        $this->request = $this->createMock(\Magento\Framework\App\Request\Http::class);
+        $this->request = $this->createMock(Http::class);
+        $this->context->expects($this->once())->method('getRequest')->will($this->returnValue($this->request));
 
         $this->block = new Import(
             $this->context,
@@ -54,8 +51,7 @@ class ImportTest extends \PHPUnit\Framework\TestCase
             $this->customerData,
             $this->categoryData,
             $this->productData,
-            $this->orderData,
-            $this->request
+            $this->orderData
         );
     }
 
@@ -137,7 +133,6 @@ class ImportTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->request->setParam('store', 1001);
-        $this->block->request->setParam('store', 1001);
 
         $this->assertEquals($this->request->getParam('store', 0), $this->block->getStoreId());
 

--- a/Test/Unit/Controller/AjaxTest.php
+++ b/Test/Unit/Controller/AjaxTest.php
@@ -3,6 +3,7 @@
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Json;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Model\CustomerData;
 use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerCollection;
@@ -24,284 +25,238 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Metrilo\Analytics\Api\Client;
 use Metrilo\Analytics\Controller\Adminhtml\Import\Ajax;
+use PHPUnit\Framework\TestCase;
 
-class AjaxTest extends \PHPUnit\Framework\TestCase
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class AjaxTest extends TestCase
 {
-    /**
-     * @var \Magento\Backend\App\Action\Context
-     */
-    private $context;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\CustomerData
-     */
-    private $customerModel;
-    
-    /**
-     * @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory
-     */
-    private $customerCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\CategoryData
-     */
-    private $categoryModel;
-    
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory
-     */
-    private $categoryCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\ProductData
-     */
-    private $productModel;
-    
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
-     */
-    private $productCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\DeletedProductData
-     */
-    private $deletedProductModel;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\OrderData
-     */
-    private $orderModel;
-    
-    /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\CollectionFactory
-     */
-    private $orderCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\CustomerSerializer
-     */
-    private $customerSerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\CategorySerializer
-     */
-    private $categorySerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\DeletedProductSerializer
-     */
-    private $deletedProductSerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductSerializer
-     */
-    private $productSerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\OrderSerializer
-     */
-    private $orderSerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ApiClient
-     */
-    private $apiClientHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Activity
-     */
-    private $activityHelper;
-    
-    /**
-     * @var \Magento\Framework\App\Request\Http
-     */
-    private $request;
-    
-    /**
-     * @var \Magento\Framework\Controller\Result\JsonFactory
-     */
-    private $jsonFactoryController;
-    
-    /**
-     * @var \Metrilo\Analytics\Api\Client
-     */
-    private $apiClient;
-    
-    /**
-     * @var \Metrilo\Analytics\Controller\Adminhtml\Import\Ajax
-     */
-    private $ajaxController;
-    
-    private $chunkItems       = 50;
-    private $storeIdKey       = 'storeId';
-    private $chunkIdKey       = 'chunkId';
-    private $importTypeKey    = 'importType';
-    private $activityStartKey = 'import_start';
-    private $activityEndKey   = 'import_end';
-    private $result           = [];
-    private $storeId          = 1;
-    private $chunkId          = 11;
-    private $jsonFactory;
-    private $response = [
+    private Context $context;
+
+    private Data $dataHelper;
+
+    private CustomerData $customerModel;
+
+    private CustomerCollection $customerCollection;
+
+    private CategoryData $categoryModel;
+
+    private CategoryCollection $categoryCollection;
+
+    private ProductData $productModel;
+
+    private ProductCollection $productCollection;
+
+    private DeletedProductData $deletedProductModel;
+
+    private OrderData $orderModel;
+
+    private OrderCollection $orderCollection;
+
+    private CustomerSerializer $customerSerializer;
+
+    private CategorySerializer $categorySerializer;
+
+    private DeletedProductSerializer $deletedProductSerializer;
+
+    private ProductSerializer $productSerializer;
+
+    private OrderSerializer $orderSerializer;
+
+    private ApiClient $apiClientHelper;
+
+    private Activity $activityHelper;
+
+    private Http $request;
+
+    private JsonFactory $jsonFactoryController;
+
+    private Client $apiClient;
+
+    private Ajax $ajaxController;
+
+    private int $chunkItems = 50;
+
+    private string $storeIdKey = 'storeId';
+
+    private string $chunkIdKey = 'chunkId';
+
+    private string $importTypeKey = 'importType';
+
+    private string $activityStartKey = 'import_start';
+
+    private int $storeId = 1;
+
+    private int $chunkId = 11;
+
+    private array $response = [
         'response' => 'apiCallResponse',
         'code' => 'responseCode'
     ];
-    
+
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @return void
+     */
     public function setUp(): void
     {
         $this->context = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        
+                              ->disableOriginalConstructor()
+                              ->getMock();
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['logError'])
-            ->getMock();
-        
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['logError'])
+                                 ->getMock();
+
         $this->customerModel = $this->getMockBuilder(CustomerData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCustomers'])
-            ->getMock();
-    
+                                    ->disableOriginalConstructor()
+                                    ->setMethods(['getCustomers'])
+                                    ->getMock();
+
         $this->customerCollection = $this->getMockBuilder(CustomerCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'setPageSize',
-                'setCurPage',
-                'getEmail',
-                'getCreatedAt',
-                'getFirstName',
-                'getLastName',
-                'getSubscriberStatus',
-                'getTags'
-            ])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods([
+                                             'setPageSize',
+                                             'setCurPage',
+                                             'getEmail',
+                                             'getCreatedAt',
+                                             'getFirstName',
+                                             'getLastName',
+                                             'getSubscriberStatus',
+                                             'getTags'
+                                         ])
+                                         ->getMock();
+
         $this->categoryModel = $this->getMockBuilder(CategoryData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCategories'])
-            ->getMock();
-    
+                                    ->disableOriginalConstructor()
+                                    ->setMethods(['getCategories'])
+                                    ->getMock();
+
         $this->categoryCollection = $this->getMockBuilder(CategoryCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'setPageSize',
-                'setCurPage',
-                'getId',
-                'getStoreId',
-                'getName',
-                'getRequestPath'
-            ])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods([
+                                             'setPageSize',
+                                             'setCurPage',
+                                             'getId',
+                                             'getStoreId',
+                                             'getName',
+                                             'getRequestPath'
+                                         ])
+                                         ->getMock();
+
         $this->deletedProductModel = $this->getMockBuilder(DeletedProductData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getDeletedProductOrders'])
-            ->getMock();
-    
+                                          ->disableOriginalConstructor()
+                                          ->setMethods(['getDeletedProductOrders'])
+                                          ->getMock();
+
         $this->productModel = $this->getMockBuilder(ProductData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getProducts'])
-            ->getMock();
-    
+                                   ->disableOriginalConstructor()
+                                   ->setMethods(['getProducts'])
+                                   ->getMock();
+
         $this->productCollection = $this->getMockBuilder(ProductCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'setPageSize',
-                'setCurPage',
-                'setDataToAll',
-                'getStoreId',
-                'getId',
-                'getTypeId',
-                'getImage',
-                'getPrice',
-                'getSpecialPrice',
-                'getRequestPath',
-                'getCategoryIds',
-                'getSku',
-                'getName'
-            ])
-            ->getMock();
-    
+                                        ->disableOriginalConstructor()
+                                        ->setMethods([
+                                            'setPageSize',
+                                            'setCurPage',
+                                            'setDataToAll',
+                                            'getStoreId',
+                                            'getId',
+                                            'getTypeId',
+                                            'getImage',
+                                            'getPrice',
+                                            'getSpecialPrice',
+                                            'getRequestPath',
+                                            'getCategoryIds',
+                                            'getSku',
+                                            'getName'
+                                        ])
+                                        ->getMock();
+
         $this->orderModel = $this->getMockBuilder(OrderData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getOrders'])
-            ->getMock();
-    
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['getOrders'])
+                                 ->getMock();
+
         $this->orderCollection = $this->getMockBuilder(OrderCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'setPageSize',
-                'setCurPage',
-                'addFieldToFilter',
-                'create'
-            ])
-            ->getMock();
-    
+                                      ->disableOriginalConstructor()
+                                      ->setMethods([
+                                          'setPageSize',
+                                          'setCurPage',
+                                          'addFieldToFilter',
+                                          'create'
+                                      ])
+                                      ->getMock();
+
         $this->customerSerializer = $this->getMockBuilder(CustomerSerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods(['serialize'])
+                                         ->getMock();
+
         $this->categorySerializer = $this->getMockBuilder(CategorySerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods(['serialize'])
+                                         ->getMock();
+
         $this->deletedProductSerializer = $this->getMockBuilder(DeletedProductSerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-    
+                                               ->disableOriginalConstructor()
+                                               ->setMethods(['serialize'])
+                                               ->getMock();
+
         $this->productSerializer = $this->getMockBuilder(ProductSerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-    
+                                        ->disableOriginalConstructor()
+                                        ->setMethods(['serialize'])
+                                        ->getMock();
+
         $this->orderSerializer = $this->getMockBuilder(OrderSerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-    
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['serialize'])
+                                      ->getMock();
+
         $this->apiClientHelper = $this->getMockBuilder(ApiClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getClient'])
-            ->getMock();
-    
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['getClient'])
+                                      ->getMock();
+
         $this->activityHelper = $this->getMockBuilder(Activity::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['createActivity'])
-            ->getMock();
-    
+                                     ->disableOriginalConstructor()
+                                     ->setMethods(['createActivity'])
+                                     ->getMock();
+
         $this->request = $this->getMockBuilder(Http::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
-            ->getMock();
-    
+                              ->disableOriginalConstructor()
+                              ->setMethods(['getParam'])
+                              ->getMock();
+
         $this->jsonFactoryController = $this->getMockBuilder(JsonFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create', 'setData'])
-            ->getMock();
-    
-        $this->jsonFactoryController->expects($this->any())->method('create')->will($this->returnSelf());
-        $this->jsonFactoryController->expects($this->any())->method('setData')->with($this->isType('array'));
-    
+                                            ->disableOriginalConstructor()
+                                            ->setMethods(['create', 'setData'])
+                                            ->getMock();
+
+        $json = $this->getMockBuilder(Json::class)
+                     ->disableOriginalConstructor()
+                     ->getMock();
+        $this->jsonFactoryController->expects($this->any())->method('create')->will($this->returnValue($json));
+
+        $json->expects($this->any())
+             ->method('setData')
+             ->with($this->isType('array'))
+             ->will($this->returnSelf());
+
         $this->apiClient = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['customerBatch', 'categoryBatch', 'productBatch', 'orderBatch'])
-            ->getMock();
-    
+                                ->disableOriginalConstructor()
+                                ->setMethods(['customerBatch', 'categoryBatch', 'productBatch', 'orderBatch'])
+                                ->getMock();
+
         $this->apiClientHelper->expects($this->any())->method('getClient')
-            ->with($this->equalTo($this->storeId))
-            ->will($this->returnValue($this->apiClient));
-        
+                              ->with($this->equalTo($this->storeId))
+                              ->will($this->returnValue($this->apiClient));
+
         $this->ajaxController = new Ajax(
-            $this->context,
             $this->dataHelper,
             $this->customerModel,
             $this->categoryModel,
@@ -319,317 +274,302 @@ class AjaxTest extends \PHPUnit\Framework\TestCase
             $this->jsonFactoryController
         );
     }
-    
+
     public function testExecuteCustomers()
     {
-        $customerEmail        = 'customer@email.com';
-        $customerCreatedAt    = '01.09.19';
-        $customerFirstName    = 'customerFirstName';
-        $customerLastName     = 'customerLastName';
+        $customerEmail = 'customer@email.com';
+        $customerCreatedAt = '01.09.19';
+        $customerFirstName = 'customerFirstName';
+        $customerLastName = 'customerLastName';
         $customerSubscription = true;
-        $customerGroup        = 'customerGroup';
-        
+        $customerGroup = 'customerGroup';
+
         $expected = [
-            'email'       => $customerEmail,
-            'createdAt'   => $customerCreatedAt,
-            'firstName'   => $customerFirstName,
-            'lastName'    => $customerLastName,
-            'subscribed'  => $customerSubscription,
-            'tags'        => $customerGroup
+            'email' => $customerEmail,
+            'createdAt' => $customerCreatedAt,
+            'firstName' => $customerFirstName,
+            'lastName' => $customerLastName,
+            'subscribed' => $customerSubscription,
+            'tags' => $customerGroup
         ];
-        
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo($this->storeIdKey))
-            ->will($this->returnValue($this->storeId));
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo($this->chunkIdKey))
-            ->will($this->returnValue($this->chunkId));
-        $this->request->expects($this->at(2))->method('getParam')
-            ->with($this->equalTo($this->importTypeKey))
-            ->will($this->returnValue('customers'));
-        
+
+        $this->request->expects($this->exactly(3))->method('getParam')
+                      ->willReturnMap([
+                          [$this->storeIdKey, $this->storeId],
+                          [$this->chunkIdKey, $this->chunkId],
+                          [$this->importTypeKey, 'customers']
+                      ]);
+
         $this->activityHelper->expects($this->any())->method('createActivity')
-            ->with($this->equalTo($this->storeId), $this->equalTo($this->activityStartKey))
-            ->will($this->returnValue(true));
-    
+                             ->with($this->equalTo($this->storeId), $this->equalTo($this->activityStartKey))
+                             ->will($this->returnValue(true));
+
         $this->customerModel->expects($this->any())->method('getCustomers')
-            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
-            ->will($this->returnValue($this->customerCollection));
-        
+                            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
+                            ->will($this->returnValue($this->customerCollection));
+
         $this->customerCollection->expects($this->any())->method('setPageSize')
-            ->with($this->equalTo($this->chunkItems));
+                                 ->with($this->equalTo($this->chunkItems));
         $this->customerCollection->expects($this->any())->method('setCurPage')
-            ->with($this->equalTo($this->chunkId));
+                                 ->with($this->equalTo($this->chunkId));
         $this->customerCollection->expects($this->any())->method('getEmail')
-            ->will($this->returnValue($customerEmail));
+                                 ->will($this->returnValue($customerEmail));
         $this->customerCollection->expects($this->any())->method('getCreatedAt')
-            ->will($this->returnValue($customerCreatedAt));
+                                 ->will($this->returnValue($customerCreatedAt));
         $this->customerCollection->expects($this->any())->method('getFirstName')
-            ->will($this->returnValue($customerFirstName));
+                                 ->will($this->returnValue($customerFirstName));
         $this->customerCollection->expects($this->any())->method('getLastName')
-            ->will($this->returnValue($customerLastName));
+                                 ->will($this->returnValue($customerLastName));
         $this->customerCollection->expects($this->any())->method('getSubscriberStatus')
-            ->will($this->returnValue($customerSubscription));
+                                 ->will($this->returnValue($customerSubscription));
         $this->customerCollection->expects($this->any())->method('getTags')
-            ->will($this->returnValue($customerGroup));
-    
+                                 ->will($this->returnValue($customerGroup));
+
         $this->customerSerializer->expects($this->any())->method('serialize')
-            ->with($this->assertInstanceOf(CustomerCollection::class, $this->customerCollection))
-            ->will($this->returnValue($expected));
-        
+                                 ->with($this->customerCollection)
+                                 ->will($this->returnValue($expected));
+
         $this->apiClient->expects($this->any())->method('customerBatch')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($this->response));
-        
+                        ->with($this->isType('array'))
+                        ->will($this->returnValue($this->response));
+
         $this->ajaxController->execute();
     }
-    
+
     public function testExecuteCategories()
     {
-        $categoryId   = 123;
+        $categoryId = 123;
         $categoryName = 'categoryName';
-        $categoryUrl  = 'categoryUrl';
-    
+        $categoryUrl = 'categoryUrl';
+
         $expected = [
-            'id'   => $categoryId,
+            'id' => $categoryId,
             'name' => $categoryName,
-            'url'  => $categoryUrl
+            'url' => $categoryUrl
         ];
-        
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo($this->storeIdKey))
-            ->will($this->returnValue($this->storeId));
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo($this->chunkIdKey))
-            ->will($this->returnValue($this->chunkId));
-        $this->request->expects($this->at(2))->method('getParam')
-            ->with($this->equalTo($this->importTypeKey))
-            ->will($this->returnValue('categories'));
-    
+
+        $this->request->expects($this->exactly(3))->method('getParam')
+                      ->willReturnMap([
+                          [$this->storeIdKey, $this->storeId],
+                          [$this->chunkIdKey, $this->chunkId],
+                          [$this->importTypeKey, 'categories']
+                      ]);
+
         $this->categoryModel->expects($this->any())->method('getCategories')
-            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
-            ->will($this->returnValue($this->categoryCollection));
-    
+                            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
+                            ->will($this->returnValue($this->categoryCollection));
+
         $this->categoryCollection->expects($this->any())->method('setPageSize')
-            ->with($this->equalTo($this->chunkItems));
+                                 ->with($this->equalTo($this->chunkItems));
         $this->categoryCollection->expects($this->any())->method('setCurPage')
-            ->with($this->equalTo($this->chunkId));
+                                 ->with($this->equalTo($this->chunkId));
         $this->categoryCollection->expects($this->any())->method('getId')
-            ->will($this->returnValue($categoryId));
+                                 ->will($this->returnValue($categoryId));
         $this->categoryCollection->expects($this->any())->method('getName')
-            ->will($this->returnValue($categoryName));
+                                 ->will($this->returnValue($categoryName));
         $this->categoryCollection->expects($this->any())->method('getRequestPath')
-            ->will($this->returnValue($categoryUrl));
-    
+                                 ->will($this->returnValue($categoryUrl));
+
         $this->categorySerializer->expects($this->any())->method('serialize')
-            ->with($this->assertInstanceOf(CategoryCollection::class, $this->categoryCollection))
-            ->will($this->returnValue($expected));
-    
+                                 ->with($this->categoryCollection)
+                                 ->will($this->returnValue($expected));
+
         $this->apiClient->expects($this->any())->method('categoryBatch')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($this->response));
-    
+                        ->with($this->isType('array'))
+                        ->will($this->returnValue($this->response));
+
         $this->ajaxController->execute();
     }
-    
+
     public function testExecuteDeletedProducts()
     {
         $delProdCategories = [];
-        $delProdId         = 333;
-        $delProdSku        = 'delProdSku';
-        $delProdImgUrl     = '';
-        $delProdName       = 'delProdName';
-        $delProdPrice      = 1000;
-        $delProdUrl        = 'delProdUrl';
-        $delProdOptions[]  = [
-            'id'       => 'itemSku',
-            'sku'      => 'itemSku',
-            'name'     => 'itemName',
-            'price'    => 'itemPrice',
+        $delProdId = 333;
+        $delProdSku = 'delProdSku';
+        $delProdImgUrl = '';
+        $delProdName = 'delProdName';
+        $delProdPrice = 1000;
+        $delProdUrl = 'delProdUrl';
+        $delProdOptions[] = [
+            'id' => 'itemSku',
+            'sku' => 'itemSku',
+            'name' => 'itemName',
+            'price' => 'itemPrice',
             'imageUrl' => ''
         ];
-        
+
         $expected[] = [
             'categories' => $delProdCategories,
-            'id'         => $delProdId,
-            'sku'        => $delProdSku,
-            'imageUrl'   => $delProdImgUrl,
-            'name'       => $delProdName,
-            'price'      => $delProdPrice,
-            'url'        => $delProdUrl,
-            'options'    => $delProdOptions
+            'id' => $delProdId,
+            'sku' => $delProdSku,
+            'imageUrl' => $delProdImgUrl,
+            'name' => $delProdName,
+            'price' => $delProdPrice,
+            'url' => $delProdUrl,
+            'options' => $delProdOptions
         ];
-    
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo($this->storeIdKey))
-            ->will($this->returnValue($this->storeId));
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo($this->chunkIdKey))
-            ->will($this->returnValue($this->chunkId));
-        $this->request->expects($this->at(2))->method('getParam')
-            ->with($this->equalTo($this->importTypeKey))
-            ->will($this->returnValue('deletedProducts'));
-    
+
+        $this->request->expects($this->exactly(3))->method('getParam')
+                      ->willReturnMap([
+                          [$this->storeIdKey, $this->storeId],
+                          [$this->chunkIdKey, $this->chunkId],
+                          [$this->importTypeKey, 'deletedProducts']
+                      ]);
+
         $this->deletedProductModel->expects($this->any())->method('getDeletedProductOrders')
-            ->with($this->equalTo($this->storeId))
-            ->will($this->returnValue($this->orderCollection));
-    
+                                  ->with($this->equalTo($this->storeId))
+                                  ->will($this->returnValue($this->orderCollection));
+
         $this->orderCollection->expects($this->any())->method('create')
-            ->will($this->returnSelf());
+                              ->will($this->returnSelf());
         $this->orderCollection->expects($this->any())->method('addFieldToFilter')
-            ->with($this->equalTo('entity_id'), $this->isType('array'))
-            ->will($this->returnValue($this->orderCollection));
-    
+                              ->with($this->equalTo('entity_id'), $this->isType('array'))
+                              ->will($this->returnValue($this->orderCollection));
+
         $this->deletedProductSerializer->expects($this->any())->method('serialize')
-            ->with($this->assertInstanceOf(OrderCollection::class, $this->orderCollection))
-            ->will($this->returnValue($expected));
-    
+                                       ->with($this->orderCollection)
+                                       ->will($this->returnValue($expected));
+
         $this->apiClient->expects($this->any())->method('productBatch')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($this->response));
-    
+                        ->with($this->isType('array'))
+                        ->will($this->returnValue($this->response));
+
         $this->ajaxController->execute();
     }
-    
+
     public function testExecuteProducts()
     {
-        $productCategories = [1,2,3];
-        $productId         = 9090;
-        $productSku        = 'productSku';
-        $productImageUrl   = 'productImageUrl';
-        $productName       = 'productName';
-        $productPrice      = 1001;
-        $productUrl        = 'productUrl';
-        $productOptions[]  = [
-            'id'       => 9091,
-            'sku'      => 'childProductSku',
-            'name'     => 'childProductName',
-            'price'    => 1003,
+        $productCategories = [1, 2, 3];
+        $productId = 9090;
+        $productSku = 'productSku';
+        $productImageUrl = 'productImageUrl';
+        $productName = 'productName';
+        $productPrice = 1001;
+        $productUrl = 'productUrl';
+        $productOptions[] = [
+            'id' => 9091,
+            'sku' => 'childProductSku',
+            'name' => 'childProductName',
+            'price' => 1003,
             'imageUrl' => 'childProductImageUrl'
         ];
-        
+
         $expected = [
             'categories' => $productCategories,
-            'id'         => $productId,
-            'sku'        => $productSku,
-            'imageUrl'   => $productImageUrl,
-            'name'       => $productName,
-            'price'      => $productPrice,
-            'url'        => $productUrl,
-            'options'    => $productOptions
+            'id' => $productId,
+            'sku' => $productSku,
+            'imageUrl' => $productImageUrl,
+            'name' => $productName,
+            'price' => $productPrice,
+            'url' => $productUrl,
+            'options' => $productOptions
         ];
-    
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo($this->storeIdKey))
-            ->will($this->returnValue($this->storeId));
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo($this->chunkIdKey))
-            ->will($this->returnValue($this->chunkId));
-        $this->request->expects($this->at(2))->method('getParam')
-            ->with($this->equalTo($this->importTypeKey))
-            ->will($this->returnValue('products'));
-    
+
+        $this->request->expects($this->exactly(3))->method('getParam')
+                      ->willReturnMap([
+                          [$this->storeIdKey, $this->storeId],
+                          [$this->chunkIdKey, $this->chunkId],
+                          [$this->importTypeKey, 'products']
+                      ]);
+
         $this->productModel->expects($this->any())->method('getProducts')
-            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
-            ->will($this->returnValue($this->productCollection));
-    
+                           ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
+                           ->will($this->returnValue($this->productCollection));
+
         $this->productCollection->expects($this->any())->method('setPageSize')
-            ->with($this->equalTo($this->chunkItems));
+                                ->with($this->equalTo($this->chunkItems));
         $this->productCollection->expects($this->any())->method('setCurPage')
-            ->with($this->equalTo($this->chunkId));
+                                ->with($this->equalTo($this->chunkId));
         $this->productCollection->expects($this->any())->method('setDataToAll')
-            ->with($this->equalTo('store_id'), $this->equalTo($this->storeId));
+                                ->with($this->equalTo('store_id'), $this->equalTo($this->storeId));
         $this->productCollection->expects($this->any())->method('getStoreId')
-            ->with($this->equalTo($this->storeId));
+                                ->with($this->equalTo($this->storeId));
         $this->productCollection->expects($this->any())->method('getId')
-            ->will($this->returnValue($productId));
+                                ->will($this->returnValue($productId));
         $this->productCollection->expects($this->any())->method('getTypeId')
-            ->will($this->returnValue('simple'));
+                                ->will($this->returnValue('simple'));
         $this->productCollection->expects($this->any())->method('getImage')
-            ->will($this->returnValue($productImageUrl));
+                                ->will($this->returnValue($productImageUrl));
         $this->productCollection->expects($this->any())->method('getPrice')
-            ->will($this->returnValue($productPrice));
+                                ->will($this->returnValue($productPrice));
         $this->productCollection->expects($this->any())->method('getSpecialPrice')
-            ->will($this->returnValue(999));
+                                ->will($this->returnValue(999));
         $this->productCollection->expects($this->any())->method('getCategoryIds')
-            ->will($this->returnValue($productCategories));
+                                ->will($this->returnValue($productCategories));
         $this->productCollection->expects($this->any())->method('getSku')
-            ->will($this->returnValue($productSku));
+                                ->will($this->returnValue($productSku));
         $this->productCollection->expects($this->any())->method('getName')
-            ->will($this->returnValue($productName));
-    
+                                ->will($this->returnValue($productName));
+
         $this->productSerializer->expects($this->any())->method('serialize')
-            ->with($this->assertInstanceOf(ProductCollection::class, $this->productCollection))
-            ->will($this->returnValue($expected));
-    
+                                ->with($this->productCollection)
+                                ->will($this->returnValue($expected));
+
         $this->apiClient->expects($this->any())->method('productBatch')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($this->response));
-    
+                        ->with($this->isType('array'))
+                        ->will($this->returnValue($this->response));
+
         $this->ajaxController->execute();
     }
-    
+
     public function testExecuteOrders()
     {
         $orderIncrementId = 1000000001;
-        $orderTimeStamp   = 1928310923;
-        $orderEmail       = 'order@email.com';
-        $orderAmount      = 900;
-        $orderCoupons     = ['couponCode'];
-        $orderStatus      = 'orderStatus';
-        $orderProducts[]  = [
-            'productId'  => 'orderItemSku',
-            'quantity'   => 3
+        $orderTimeStamp = 1928310923;
+        $orderEmail = 'order@email.com';
+        $orderAmount = 900;
+        $orderCoupons = ['couponCode'];
+        $orderStatus = 'orderStatus';
+        $orderProducts[] = [
+            'productId' => 'orderItemSku',
+            'quantity' => 3
         ];
-        $orderBilling     = [
-            "firstName"     => 'customerFirstName',
-            "lastName"      => 'customerLastName',
-            "address"       => 'streetAddress',
-            "city"          => 'orderCity',
-            "countryCode"   => 'orderCountryCode',
-            "phone"         => 'orderPhone',
-            "postcode"      => 'orderPostcode',
+        $orderBilling = [
+            "firstName" => 'customerFirstName',
+            "lastName" => 'customerLastName',
+            "address" => 'streetAddress',
+            "city" => 'orderCity',
+            "countryCode" => 'orderCountryCode',
+            "phone" => 'orderPhone',
+            "postcode" => 'orderPostcode',
             "paymentMethod" => 'orderPaymentMethodName'
         ];
-        
+
         $expected = [
-            'id'        => $orderIncrementId,
+            'id' => $orderIncrementId,
             'createdAt' => $orderTimeStamp,
-            'email'     => $orderEmail,
-            'amount'    => $orderAmount,
-            'coupons'   => $orderCoupons,
-            'status'    => $orderStatus,
-            'products'  => $orderProducts,
-            'billing'   => $orderBilling
+            'email' => $orderEmail,
+            'amount' => $orderAmount,
+            'coupons' => $orderCoupons,
+            'status' => $orderStatus,
+            'products' => $orderProducts,
+            'billing' => $orderBilling
         ];
-    
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo($this->storeIdKey))
-            ->will($this->returnValue($this->storeId));
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo($this->chunkIdKey))
-            ->will($this->returnValue($this->chunkId));
-        $this->request->expects($this->at(2))->method('getParam')
-            ->with($this->equalTo($this->importTypeKey))
-            ->will($this->returnValue('orders'));
-    
+
+        $this->request->expects($this->exactly(3))->method('getParam')
+                      ->willReturnMap([
+                          [$this->storeIdKey, $this->storeId],
+                          [$this->chunkIdKey, $this->chunkId],
+                          [$this->importTypeKey, 'orders']
+                      ]);
+
         $this->orderModel->expects($this->any())->method('getOrders')
-            ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
-            ->will($this->returnValue($this->orderCollection));
-    
+                         ->with($this->equalTo($this->storeId), $this->equalTo($this->chunkId))
+                         ->will($this->returnValue($this->orderCollection));
+
         $this->orderCollection->expects($this->any())->method('setPageSize')
-            ->with($this->equalTo($this->chunkItems));
+                              ->with($this->equalTo($this->chunkItems));
         $this->orderCollection->expects($this->any())->method('setCurPage')
-            ->with($this->equalTo($this->chunkId));
-    
+                              ->with($this->equalTo($this->chunkId));
+
         $this->orderSerializer->expects($this->any())->method('serialize')
-            ->with($this->assertInstanceOf(OrderCollection::class, $this->orderCollection))
-            ->will($this->returnValue($expected));
-    
+                              ->with($this->orderCollection)
+                              ->will($this->returnValue($expected));
+
         $this->apiClient->expects($this->any())->method('orderBatch')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($this->response));
-    
+                        ->with($this->isType('array'))
+                        ->will($this->returnValue($this->response));
+
         $this->ajaxController->execute();
     }
 }

--- a/Test/Unit/Helper/ActivityTest.php
+++ b/Test/Unit/Helper/ActivityTest.php
@@ -2,60 +2,54 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Framework\App\Helper\Context;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\ApiClient;
 use Metrilo\Analytics\Helper\Activity;
 use Metrilo\Analytics\Api\Client;
+use PHPUnit\Framework\TestCase;
 
-class ActivityTest extends \PHPUnit\Framework\TestCase
+class ActivityTest extends TestCase
 {
-    /**
-     * @var Activity
-     */
-    private $activityHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ApiClient
-     */
-    private $apiClientHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Api\Client
-     */
-    private $client;
-    
+    private Activity $activityHelper;
+
+    private Data $dataHelper;
+
+    private ApiClient $apiClientHelper;
+
+    private Client $client;
+
     /**
      * @var String
      */
-    private $type = 'integrated';
-    
-    private $storeId = 1;
-    
+    private string $type = 'integrated';
+
+    private int $storeId = 1;
+
     public function setUp(): void
     {
         $this->dataHelper = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
             ->setMethods(['getApiToken', 'getApiSecret', 'getActivityEndpoint'])
             ->getMock();
-    
+
         $this->apiClientHelper = $this->getMockBuilder(ApiClient::class)
             ->disableOriginalConstructor()
             ->setMethods(['getClient'])
             ->getMock();
-    
+
         $this->client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->setMethods(['createActivity'])
             ->getMock();
-        
-        $this->activityHelper = new Activity($this->dataHelper, $this->apiClientHelper);
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $this->activityHelper = new Activity($this->dataHelper, $this->apiClientHelper, $context);
     }
-    
+
     public function testCreateActivity()
     {
         $this->dataHelper->expects($this->any())->method('getApiToken')
@@ -66,23 +60,23 @@ class ActivityTest extends \PHPUnit\Framework\TestCase
             ->willReturn('82535e6593b51afed58e0a5a');
         $this->dataHelper->expects($this->any())->method('getActivityEndpoint')
             ->willReturn('https://p.metrilo.com');
-        
+
         $this->apiClientHelper->expects($this->any())->method('getClient')
             ->with($this->equalTo($this->storeId))
             ->willReturn($this->client);
-    
+
         $data = [
             'type'   => $this->type,
             'secret' => $this->dataHelper->getApiSecret($this->storeId)
         ];
-    
+
         $url = $this->dataHelper->getActivityEndpoint() . '/tracking/' .
             $this->dataHelper->getApiToken($this->storeId) . '/activity';
-        
+
         $this->client->expects($this->any())->method('createActivity')
             ->with($this->equalTo($url), $this->equalTo($data))
             ->willReturn(true);
-        
+
         $this->assertTrue($this->activityHelper->createActivity($this->storeId, $this->type));
     }
 }

--- a/Test/Unit/Helper/ApiClientTest.php
+++ b/Test/Unit/Helper/ApiClientTest.php
@@ -2,96 +2,148 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadata;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\Serialize\Serializer\Json;
+use Metrilo\Analytics\Api\ClientFactory;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\ApiClient;
 use Metrilo\Analytics\Api\Client;
+use PHPUnit\Framework\TestCase;
 
-class ApiClientTest extends \PHPUnit\Framework\TestCase
+class ApiClientTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\App\ProductMetadata
-     */
-    private $metaData;
-    
-    /**
-     * @var \Magento\Framework\Module\ModuleListInterface
-     */
-    private $moduleList;
-    
-    /**
-     * @var \Magento\Framework\Filesystem\DirectoryList
-     */
-    private $directoryList;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ApiClient
-     */
-    private $apiClient;
-    
-    /**
-     * @var \Metrilo\Analytics\Api\Client
-     */
-    private $client;
-    
+    private ProductMetadata $metaData;
+
+    private Data $dataHelper;
+
+    private ApiClient $apiClient;
+
     /**
      * @var \Magento\Framework\App\Request\Http->getParam('store', 0)
      */
-    private $storeId = 1;
-    
+    private int $storeId = 1;
+
+    private ComponentRegistrarInterface $componentRegistrar;
+
+    private Json $json;
+
+    private ReadInterface $read;
+
+    private ClientFactory $clientFactory;
+
+    private Client $client;
+
     public function setUp(): void
     {
         $this->metaData = $this->getMockBuilder(ProductMetadata::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEdition', 'getVersion'])
-            ->getMock();
-    
-        $this->moduleList = $this->getMockBuilder(ModuleListInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getOne', 'getAll', 'getNames', 'has'])
-            ->getMock();
-    
-        $this->directoryList = $this->getMockBuilder(DirectoryList::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getPath'])
-            ->getMock();
-    
+                               ->disableOriginalConstructor()
+                               ->setMethods(['getEdition', 'getVersion'])
+                               ->getMock();
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getApiToken', 'getApiSecret', 'getApiEndpoint'])
-            ->getMock();
-        
-        $this->apiClient = new ApiClient($this->dataHelper, $this->metaData, $this->moduleList, $this->directoryList);
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['getApiToken', 'getApiSecret', 'getApiEndpoint'])
+                                 ->getMock();
+
+        $this->read = $this->getMockBuilder(ReadInterface::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $readFactory = $this->getMockBuilder(ReadFactory::class)
+                            ->disableOriginalConstructor()
+                            ->getMock();
+        $readFactory->expects($this->once())
+                    ->method('create')
+                    ->with($this->isType('string'))
+                    ->will($this->returnValue($this->read));
+
+        $this->componentRegistrar = $this->getMockBuilder(ComponentRegistrarInterface::class)
+                                         ->disableOriginalConstructor()
+                                         ->getMock();
+
+        $this->json = $this->getMockBuilder(Json::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $this->client = $this->getMockBuilder(Client::class)
+                             ->disableOriginalConstructor()
+                             ->getMock();
+
+        $this->clientFactory = $this->getMockBuilder(ClientFactory::class)
+                                    ->disableOriginalConstructor()
+                                    ->getMock();
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $this->apiClient = new ApiClient(
+            $this->dataHelper,
+            $this->metaData,
+            $this->clientFactory,
+            $this->componentRegistrar,
+            $readFactory,
+            $this->json,
+            $context
+        );
     }
-    
+
     public function testGetClient()
     {
         $this->metaData->expects($this->any())->method('getEdition')
-            ->will($this->returnValue('123'));
+                       ->will($this->returnValue('123'));
         $this->metaData->expects($this->any())->method('getVersion')
-            ->will($this->returnValue('321'));
-        
-        $this->moduleList->expects($this->any())->method('getOne')
-            ->with($this->isType('string'))
-            ->will($this->returnValue(['setup_version' => '222']));
-        
-        $this->directoryList->expects($this->any())->method('getPath')
-            ->with($this->equalTo('log'))
-            ->will($this->returnValue('path/to/log/dir'));
-        
+                       ->will($this->returnValue('321'));
+
+        $this->componentRegistrar->expects($this->once())
+                                 ->method('getPath')
+                                 ->with(ComponentRegistrar::MODULE, 'Metrilo_Analytics')
+                                 ->will($this->returnValue('some/path/to/package'));
+
+        $encoded = '{"name":"metrilo\/analytics-magento2-extension","version":"2.1.0"}';
+
+        $this->read->expects($this->once())
+                   ->method('readFile')
+                   ->with('composer.json')
+                   ->will($this->returnValue($encoded));
+
+        $this->json->expects($this->once())
+                   ->method('unserialize')
+                   ->with($encoded)
+                   ->will(
+                       $this->returnValue([
+                           "name" => "metrilo/analytics-magento2-extension",
+                           "version" => "2.1.0"
+                       ])
+                   );
+
         $this->dataHelper->expects($this->any())->method('getApiToken')
-            ->with($this->equalTo($this->storeId))
-            ->will($this->returnValue('9b4dd74a736d9d7d'));
+                         ->with($this->equalTo($this->storeId))
+                         ->will($this->returnValue('9b4dd74a736d9d7d'));
         $this->dataHelper->expects($this->any())->method('getApiEndpoint')
-            ->will($this->returnValue('https://trk.mtrl.me'));
-        
+                         ->will($this->returnValue('https://trk.mtrl.me'));
+
+        $this->dataHelper->expects($this->once())->method('getApiSecret')
+                         ->with($this->storeId)->will($this->returnValue('secret-token-here'));
+
+        $this->clientFactory->expects($this->once())
+                            ->method('create')
+                            ->with([
+                                'token' => '9b4dd74a736d9d7d',
+                                'secret' => 'secret-token-here',
+                                'platform' => 'Magento 123 321',
+                                'pluginVersion' => '2.1.0',
+                                'apiEndpoint' => 'https://trk.mtrl.me',
+                            ])
+                            ->will($this->returnValue($this->client));
+
         $this->assertInstanceOf(Client::class, $this->apiClient->getClient($this->storeId));
     }
 }

--- a/Test/Unit/Helper/CategorySerializerTest.php
+++ b/Test/Unit/Helper/CategorySerializerTest.php
@@ -3,77 +3,75 @@
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\StoreManagerInterface;
 use Metrilo\Analytics\Helper\CategorySerializer;
+use PHPUnit\Framework\TestCase;
 
-class CategorySerializerTest extends \PHPUnit\Framework\TestCase
+class CategorySerializerTest extends TestCase
 {
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Category\Collection
-     */
-    private $categoryCollection;
-    
-    /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    private $storeManager;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\CategorySerializer
-     */
-    private $categorySerializer;
-    
+    private Collection $categoryCollection;
+
+    private StoreManagerInterface $storeManager;
+
+    private CategorySerializer $categorySerializer;
+
     public function setUp(): void
     {
         $this->categoryCollection = $this->getMockBuilder(Collection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getStoreId', 'getName', 'getRequestPath'])
-            ->getMock();
-    
+                                         ->disableOriginalConstructor()
+                                         ->setMethods(['getId', 'getStoreId', 'getName', 'getRequestPath'])
+                                         ->getMock();
+
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'getStore',
-                'getBaseUrl',
-                'setIsSingleStoreModeAllowed',
-                'hasSingleStore',
-                'isSingleStoreMode',
-                'getStores',
-                'getWebsite',
-                'getWebsites',
-                'reinitStores',
-                'getDefaultStoreView',
-                'getGroup',
-                'getGroups',
-                'setCurrentStore'])
-            ->getMock();
-        
-        $this->categorySerializer = new CategorySerializer($this->storeManager);
+                                   ->disableOriginalConstructor()
+                                   ->setMethods([
+                                       'getStore',
+                                       'getBaseUrl',
+                                       'setIsSingleStoreModeAllowed',
+                                       'hasSingleStore',
+                                       'isSingleStoreMode',
+                                       'getStores',
+                                       'getWebsite',
+                                       'getWebsites',
+                                       'reinitStores',
+                                       'getDefaultStoreView',
+                                       'getGroup',
+                                       'getGroups',
+                                       'setCurrentStore'
+                                   ])
+                                   ->getMock();
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $this->categorySerializer = new CategorySerializer($this->storeManager, $context);
     }
-    
+
     public function testSerialize()
     {
         $this->categoryCollection->expects($this->any())->method('getId')
-            ->will($this->returnValue(1));
+                                 ->will($this->returnValue(1));
         $this->categoryCollection->expects($this->any())->method('getStoreId')
-            ->will($this->returnValue(1));
+                                 ->will($this->returnValue(1));
         $this->categoryCollection->expects($this->any())->method('getName')
-            ->will($this->returnValue('name'));
+                                 ->will($this->returnValue('name'));
         $this->categoryCollection->expects($this->any())->method('getRequestPath')
-            ->will($this->returnValue('/url/request/path'));
-        
+                                 ->will($this->returnValue('/url/request/path'));
+
         $this->storeManager->expects($this->any())->method('getStore')
-            ->with($this->isType('int'))
-            ->will($this->returnSelf());
+                           ->with($this->isType('int'))
+                           ->will($this->returnSelf());
         $this->storeManager->expects($this->any())->method('getBaseUrl')
-            ->will($this->returnValue('base/url/string'));
-        
-        $expected = array(
-            'id'   => 1,
+                           ->will($this->returnValue('base/url/string'));
+
+        $expected = [
+            'id' => 1,
             'name' => 'name',
-            'url'  => 'base/url/string/url/request/path'
-        );
-        
+            'url' => 'base/url/string/url/request/path'
+        ];
+
         $this->assertEquals($expected, $this->categorySerializer->serialize($this->categoryCollection));
     }
 }

--- a/Test/Unit/Helper/CustomerSerializerTest.php
+++ b/Test/Unit/Helper/CustomerSerializerTest.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Framework\App\Helper\Context;
 use Magento\Customer\Model\ResourceModel\Customer\Collection;
-use Metrilo\Analytics\Helper\MetriloCustomer;
+use Metrilo\Analytics\Model\MetriloCustomer;
 use Metrilo\Analytics\Helper\CustomerSerializer;
 
 class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
@@ -13,41 +13,41 @@ class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Framework\App\Helper\Context
      */
     private $context;
-    
+
     /**
      * @var \Magento\Customer\Model\ResourceModel\Customer\Collection
      */
     private $customerCollection;
-    
+
     /**
-     * @var \Metrilo\Analytics\Helper\MetriloCustomer
+     * @var \Metrilo\Analytics\Model\MetriloCustomer
      */
     private $metriloCustomer;
-    
+
     /**
      * @var \Metrilo\Analytics\Helper\CustomerSerializer
      */
     private $customerSerializer;
-    
+
     public function setUp(): void
     {
         $this->context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $this->customerCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(['getEmail', 'getCreatedAt', 'getFirstName', 'getLastName', 'getSubscriberStatus', 'getTags'])
             ->getMock();
-        
+
         $this->metriloCustomer = $this->getMockBuilder(MetriloCustomer::class)
             ->disableOriginalConstructor()
             ->setMethods(['getEmail', 'getCreatedAt', 'getFirstName', 'getLastName', 'getSubscriberStatus', 'getTags'])
             ->getMock();
-        
+
         $this->customerSerializer = new CustomerSerializer($this->context);
     }
-    
+
     public function testSerialize()
     {
         $this->customerCollection->expects($this->any())->method('getEmail')
@@ -62,7 +62,7 @@ class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(true));
         $this->customerCollection->expects($this->any())->method('getTags')
             ->will($this->returnValue('customerGroup'));
-    
+
         $this->metriloCustomer->expects($this->any())->method('getEmail')
             ->will($this->returnValue('metriloCustomer@email.com'));
         $this->metriloCustomer->expects($this->any())->method('getCreatedAt')
@@ -75,7 +75,7 @@ class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(false));
         $this->metriloCustomer->expects($this->any())->method('getTags')
             ->will($this->returnValue('metriloCustomerGroup'));
-    
+
         $expectedCustomerCollection = [
             'email'       => 'customer@email.com',
             'createdAt'   => 'date: 02.25.20',
@@ -84,7 +84,7 @@ class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => true,
             'tags'        => 'customerGroup'
         ];
-    
+
         $expectedMetriloCustomer = [
             'email'       => 'metriloCustomer@email.com',
             'createdAt'   => 'metriloDate: 02.25.20',
@@ -93,7 +93,7 @@ class CustomerSerializerTest extends \PHPUnit\Framework\TestCase
             'subscribed'  => false,
             'tags'        => 'metriloCustomerGroup'
         ];
-    
+
         $this->assertEquals(
             $expectedCustomerCollection,
             $this->customerSerializer->serialize($this->customerCollection)

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -3,143 +3,130 @@
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Metrilo\Analytics\Helper\Data;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
-class DataTest extends \PHPUnit\Framework\TestCase
+class DataTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
-     */
-    private $config;
-    
-    /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    private $storeManager;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $data;
-    
+    private ScopeConfigInterface $config;
+
+    private StoreManagerInterface $storeManager;
+
+    private Data $data;
+
     /**
      * @var \Magento\Framework\App\Request\Http->getParam('store', 0)
      */
     private $storeId = 1;
-    
+
     public function setUp(): void
     {
         $this->config = $this->getMockBuilder(ScopeConfigInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getValue'])
-            ->getMockForAbstractClass();
-        
+                             ->disableOriginalConstructor()
+                             ->setMethods(['getValue'])
+                             ->getMockForAbstractClass();
+
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getStore', 'getId'])
-            ->getMockForAbstractClass();
-        
-        $this->data = new Data($this->config, $this->storeManager);
+                                   ->disableOriginalConstructor()
+                                   ->setMethods(['getStore', 'getId'])
+                                   ->getMockForAbstractClass();
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+        $context->method('getScopeConfig')->will($this->returnValue($this->config));
+
+        $this->data = new Data($this->storeManager, $logger, $context);
     }
-    
+
     public function testGetStoreId()
     {
         $this->storeManager->expects($this->any())->method('getStore')->will($this->returnSelf());
         $this->storeManager->expects($this->any())->method('getId')->will($this->returnValue('1'));
-        
+
         $this->assertEquals(1, $this->data->getStoreId());
     }
-    
+
     public function testIsEnabled()
     {
-        $this->config->expects($this->any())->method('getValue')
-            ->with(
-                $this->equalTo('metrilo_analytics/general/enable'),
-                $this->equalTo('store'),
-                $this->equalTo($this->storeId)
-            )
-            ->will($this->returnValue(true));
-        
+        $this->config->expects($this->any())->method('isSetFlag')
+                     ->with(
+                         $this->equalTo('metrilo_analytics/general/enable'),
+                         $this->equalTo('store'),
+                         $this->equalTo($this->storeId)
+                     )
+                     ->will($this->returnValue(true));
+
         $this->assertTrue($this->data->isEnabled($this->storeId));
     }
-    
+
     public function testGetApiToken()
     {
         $this->config->expects($this->any())->method('getValue')
-            ->with(
-                $this->equalTo('metrilo_analytics/general/api_key'),
-                $this->equalTo('store'),
-                $this->equalTo($this->storeId)
-            )
-            ->will($this->returnValue('9b4dd74a736d9d7d'));
-    
+                     ->with(
+                         $this->equalTo('metrilo_analytics/general/api_key'),
+                         $this->equalTo('store'),
+                         $this->equalTo($this->storeId)
+                     )
+                     ->will($this->returnValue('9b4dd74a736d9d7d'));
+
         $this->assertEquals('9b4dd74a736d9d7d', $this->data->getApiToken($this->storeId));
     }
-    
+
     public function testGetApiSecret()
     {
         $this->config->expects($this->any())->method('getValue')
-            ->with(
-                $this->equalTo('metrilo_analytics/general/api_secret'),
-                $this->equalTo('store'),
-                $this->equalTo($this->storeId)
-            )
-            ->will($this->returnValue('82535e6593b51afed58e0a5a'));
-    
+                     ->with(
+                         $this->equalTo('metrilo_analytics/general/api_secret'),
+                         $this->equalTo('store'),
+                         $this->equalTo($this->storeId)
+                     )
+                     ->will($this->returnValue('82535e6593b51afed58e0a5a'));
+
         $this->assertEquals('82535e6593b51afed58e0a5a', $this->data->getApiSecret($this->storeId));
     }
-    
+
     public function testGetApiEndpoint()
     {
         $this->config->expects($this->any())->method('getValue')
-            ->with($this->equalTo('metrilo_analytics/general/api_endpoint'))
-            ->will($this->returnValue('https://trk.mtrl.me'));
-    
+                     ->with($this->equalTo('metrilo_analytics/general/api_endpoint'))
+                     ->will($this->returnValue('https://trk.mtrl.me'));
+
         $this->assertEquals('https://trk.mtrl.me', $this->data->getApiEndpoint());
     }
-    
+
     public function testGetActivityEndpoint()
     {
         $this->config->expects($this->any())->method('getValue')
-            ->with($this->equalTo('metrilo_analytics/general/activity_endpoint'))
-            ->will($this->returnValue('https://p.metrilo.com'));
-    
+                     ->with($this->equalTo('metrilo_analytics/general/activity_endpoint'))
+                     ->will($this->returnValue('https://p.metrilo.com'));
+
         $this->assertEquals('https://p.metrilo.com', $this->data->getActivityEndpoint());
     }
-    
-    public function testLogError()
-    {
-        $logLocation = BP . '/var/log/metrilo.log';
-        if (file_exists($logLocation)) {
-            unlink($logLocation);
-        }
-        
-        $this->data->logError('test');
-        $result = file_exists($logLocation);
-        
-        $this->assertTrue($result);
-        $this->assertFalse(filesize($logLocation) > 10 * 1024 * 1024);
-    }
-    
+
     public function testGetStoreIdsPerProject()
     {
-        $this->config->expects($this->at(0))->method('getValue')
-            ->with(
-                $this->equalTo('metrilo_analytics/general/enable'),
-                $this->equalTo('store'),
-                $this->isType('int')
-            )
-            ->will($this->returnValue(true));
-        
-        $this->config->expects($this->at(1))->method('getValue')
-            ->with(
-                $this->equalTo('metrilo_analytics/general/api_key'),
-                $this->equalTo('store'),
-                $this->isType('int')
-            )
-            ->will($this->returnValue('9b4dd74a736d9d7d'));
-        
-        $this->assertEquals([1], $this->data->getStoreIdsPerProject([1,3,4]));
+
+        $this->config->expects($this->any())->method('isSetFlag')
+                     ->willReturnMap([
+                         ['metrilo_analytics/general/enable', ScopeInterface::SCOPE_STORE, 1, true],
+                         ['metrilo_analytics/general/enable', ScopeInterface::SCOPE_STORE, 3, true],
+                         ['metrilo_analytics/general/enable', ScopeInterface::SCOPE_STORE, 4, true]
+                     ]);
+
+        $this->config->expects($this->any())->method('isSetFlag')
+                     ->willReturnMap([
+                         ['metrilo_analytics/general/api_key', ScopeInterface::SCOPE_STORE, 1, '9b4dd74a736d9d7d'],
+                         ['metrilo_analytics/general/api_key', ScopeInterface::SCOPE_STORE, 3, '9b4dd74a736d9d7d'],
+                         ['metrilo_analytics/general/api_key', ScopeInterface::SCOPE_STORE, 4, '9b4dd74a736d9d7d']
+                     ]);
+
+        $this->assertEquals([1], $this->data->getStoreIdsPerProject([1, 3, 4]));
     }
 }

--- a/Test/Unit/Helper/DeletedProductSerializerTest.php
+++ b/Test/Unit/Helper/DeletedProductSerializerTest.php
@@ -2,147 +2,291 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Catalog\Model\Product\Type;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\App\Helper\Context;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Item;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Metrilo\Analytics\Helper\DeletedProductSerializer;
+use PHPUnit\Framework\TestCase;
 
-class DeletedProductSerializerTest extends \PHPUnit\Framework\TestCase
+class DeletedProductSerializerTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\App\Helper\Context
-     */
-    private $context;
-    
     /**
      * @var \Magento\Sales\Model\Order
      */
     private $orderModel;
-    
-    /**
-     * @var \Magento\Sales\Model\Order\Item
-     */
-    private $itemModel;
-    
+
     /**
      * @var \Magento\Sales\Model\ResourceModel\Order\CollectionFactory
      */
     private $orderCollection;
-    
+
     /**
      * @var \Metrilo\Analytics\Helper\DeletedProductSerializer
      */
     private $deletedProductSerializer;
-    
-    private $parentItemId     = 11;
-    private $parentItemPrice  = 100;
-    private $parentItemName   = 'parentName';
-    private $itemId           = 13;
-    private $itemPrice        = 101;
-    private $itemSku          = 'itemSku';
-    private $itemName         = 'itemName';
-    private $simpleItem       = 'simple';
-    private $configurableItem = 'configurable';
+
+    private int $parentItemId = 11;
+
+    private int $parentItemPrice = 100;
+
+    private string $parentItemName = 'parentName';
+
+    private string $parentSku = 'parent-sku';
+
+    private int $simpleProduct1Id = 1;
+
+    private int $simpleProduct2Id = 2;
+
+    private string $simpleProduct1Sku = 'simple-1';
+
+    private string $simpleProduct2Sku = 'simple-2';
+
+    private string $simpleProduct1Name = 'Simple 1';
+
+    private string $simpleProduct2Name = 'Simple 2';
+
+    private int $simpleProduct1Price = 50;
+
+    private int $simpleProduct2Price = 60;
 
     public function setUp(): void
     {
-        $this->context = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    
-        $this->orderModel = $this->getMockBuilder(Order::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getItemById', 'getProductId', 'getName', 'getPrice', 'getAllItems'])
-            ->getMock();
-    
-        $this->orderModel->expects($this->any())->method('getAllItems')
-            ->will($this->returnValue([$this->itemModel]));
-    
-        $this->itemModel = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentItemId', 'getProductId', 'getSku', 'getName', 'getProductType', 'getPrice'])
-            ->getMock();
-    
-        $this->itemModel->expects($this->any())->method('getProductId')
-            ->will($this->returnValue($this->itemId));
-        $this->itemModel->expects($this->any())->method('getSku')
-            ->will($this->returnValue($this->itemSku));
-        $this->itemModel->expects($this->any())->method('getName')
-            ->will($this->returnValue($this->itemName));
-        $this->itemModel->expects($this->any())->method('getPrice')
-            ->will($this->returnValue($this->itemPrice));
-    
-        $this->orderCollection = $this->getMockBuilder(CollectionFactory::class)
-            ->disableOriginalConstructor()
-//            ->setMethods(['getParentItemId', 'getProductId', 'getSku', 'getName', 'getProductType', 'getPrice'])
-            ->getMock();
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
 
-        $this->deletedProductSerializer = new DeletedProductSerializer($this->context);
+        $this->orderModel = $this->getMockBuilder(Order::class)
+                                 ->disableOriginalConstructor()
+                                 ->getMock();
+
+        $this->orderCollection = $this->getMockBuilder(Collection::class)
+                                      ->disableOriginalConstructor()
+                                      ->getMock();
+
+        $this->orderCollection->expects($this->any())->method('getIterator')
+                              ->will($this->returnValue(new \ArrayIterator([$this->orderModel])));
+
+        $this->deletedProductSerializer = new DeletedProductSerializer($context);
     }
 
+    /**
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
     public function testSerializeParentProduct()
     {
-        $this->orderModel->expects($this->any())->method('getItemById')
-            ->with($this->equalTo($this->parentItemId))
-            ->will($this->returnValue($this->orderModel));
-        $this->orderModel->expects($this->any())->method('getPrice')
-            ->will($this->returnValue($this->parentItemPrice));
-        $this->orderModel->expects($this->any())->method('getProductId')
-            ->will($this->returnValue($this->parentItemId));
-        $this->orderModel->expects($this->any())->method('getName')
-            ->will($this->returnValue($this->parentItemName));
-    
-        $this->itemModel->expects($this->any())->method('getParentItemId')
-            ->will($this->returnValue($this->parentItemId));
-        $this->itemModel->expects($this->any())->method('getProductType')
-            ->will($this->returnValue($this->configurableItem));
-        
-        $productOptions[] = [
-            'id'       => $this->itemSku,
-            'sku'      => $this->itemSku,
-            'name'     => $this->itemName,
-            'price'    => $this->parentItemPrice,
-            'imageUrl' => ''
+        $parentItem = $this->getMockBuilder(Item::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+        $childItem1 = $this->getMockBuilder(Item::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $childItem2 = $this->getMockBuilder(Item::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $parentItem->expects($this->any())
+                   ->method('getProductId')
+                   ->will($this->returnValue($this->parentItemId));
+
+        $childItem1->expects($this->any())
+                   ->method('getProductId')
+                   ->will($this->returnValue($this->simpleProduct1Id));
+
+        $childItem1->expects($this->any())
+                   ->method('getParentItemId')
+                   ->will($this->returnValue($this->parentItemId));
+
+        $childItem1->expects($this->any())
+                   ->method('getProductType')
+                   ->will($this->returnValue(Type::TYPE_SIMPLE));
+
+        $childItem1->expects($this->any())
+                   ->method('getSku')
+                   ->will($this->returnValue($this->simpleProduct1Sku));
+
+        $childItem1->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($this->simpleProduct1Name));
+
+        $childItem2->expects($this->any())
+                   ->method('getProductId')
+                   ->will($this->returnValue($this->simpleProduct2Id));
+
+        $childItem2->expects($this->any())
+                   ->method('getSku')
+                   ->will($this->returnValue($this->simpleProduct2Sku));
+
+        $childItem2->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($this->simpleProduct2Name));
+
+        $childItem2->expects($this->any())
+                   ->method('getParentItemId')
+                   ->will($this->returnValue($this->parentItemId));
+
+        $childItem2->expects($this->any())
+                   ->method('getProductType')
+                   ->will($this->returnValue(Type::TYPE_SIMPLE));
+
+        $parentItem->expects($this->any())
+                   ->method('getProductType')
+                   ->will($this->returnValue(Configurable::TYPE_CODE));
+
+        $parentItem->expects($this->once())
+                   ->method('getSku')
+                   ->will($this->returnValue($this->parentSku));
+        $parentItem->expects($this->any())
+                   ->method('getPrice')
+                   ->will($this->returnValue($this->parentItemPrice));
+        $parentItem->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($this->parentItemName));
+
+        $this->orderModel->expects($this->any())
+                         ->method('getItemById')
+                         ->with($this->parentItemId)
+                         ->will($this->returnValue($parentItem));
+
+        $this->orderModel->expects($this->any())
+                         ->method('getAllItems')
+                         ->will(
+                             $this->returnValue(
+                                 new \ArrayIterator(
+                                     [
+                                         $childItem1,
+                                         $parentItem,
+                                         $childItem2
+                                     ]
+                                 )
+                             )
+                         );
+
+        $expected[$this->parentItemId] = [
+            'categories' => [],
+            'id' => $this->parentItemId,
+            'sku' => $this->parentSku,
+            'imageUrl' => '',
+            'name' => $this->parentItemName,
+            'price' => 0,
+            'url' => '',
+            'options' => [
+                $this->simpleProduct1Id => [
+                    'id' => $this->simpleProduct1Id,
+                    'sku' => $this->simpleProduct1Sku,
+                    'name' => $this->simpleProduct1Name,
+                    'price' => $this->parentItemPrice,
+                    'imageUrl' => ''
+                ],
+                $this->simpleProduct2Id => [
+                    'id' => $this->simpleProduct2Id,
+                    'sku' => $this->simpleProduct2Sku,
+                    'name' => $this->simpleProduct2Name,
+                    'price' => $this->parentItemPrice,
+                    'imageUrl' => ''
+                ]
+            ]
         ];
 
-        $expected[] = [
-            'categories' => [],
-            'id'         => $this->parentItemId,
-            'sku'        => $this->itemSku,
-            'imageUrl'   => '',
-            'name'       => $this->parentItemName,
-            'price'      => 0,
-            'url'        => '',
-            'options'    => $productOptions
-        ];
-        
         $result = $this->deletedProductSerializer->serialize($this->orderCollection);
 
-//        $this->assertSame($expected, $result);
+        $this->assertSame($expected, $result);
     }
-    
+
     public function testSerializeChildProduct()
     {
-        $this->orderModel->expects($this->any())->method('getProductId')->will($this->returnValue(''));
-        $this->orderModel->expects($this->any())->method('getName')->will($this->returnValue(''));
-        
-        $this->itemModel->expects($this->any())->method('getParentItemId')->will($this->returnValue(''));
-        $this->itemModel->expects($this->any())->method('getProductType')->will($this->returnValue($this->simpleItem));
-        
-        $expected[] = [
-            'categories' => [],
-            'id'         => $this->itemId,
-            'sku'        => $this->itemSku,
-            'imageUrl'   => '',
-            'name'       => $this->itemName,
-            'price'      => $this->itemPrice,
-            'url'        => '',
-            'options'    => []
+        $childItem1 = $this->getMockBuilder(Item::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $childItem2 = $this->getMockBuilder(Item::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+        $childItem1->expects($this->any())
+                   ->method('getProductId')
+                   ->will($this->returnValue($this->simpleProduct1Id));
+
+        $childItem1->expects($this->any())
+                   ->method('getProductType')
+                   ->will($this->returnValue(Type::TYPE_SIMPLE));
+
+        $childItem1->expects($this->any())
+                   ->method('getSku')
+                   ->will($this->returnValue($this->simpleProduct1Sku));
+
+        $childItem1->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($this->simpleProduct1Name));
+
+        $childItem1->expects($this->once())
+                   ->method('getPrice')
+                   ->will($this->returnValue($this->simpleProduct1Price));
+
+        $childItem2->expects($this->any())
+                   ->method('getProductId')
+                   ->will($this->returnValue($this->simpleProduct2Id));
+
+        $childItem2->expects($this->any())
+                   ->method('getSku')
+                   ->will($this->returnValue($this->simpleProduct2Sku));
+
+        $childItem2->expects($this->any())
+                   ->method('getName')
+                   ->will($this->returnValue($this->simpleProduct2Name));
+
+        $childItem2->expects($this->once())
+                   ->method('getPrice')
+                   ->will($this->returnValue($this->simpleProduct2Price));
+
+        $childItem2->expects($this->any())
+                   ->method('getProductType')
+                   ->will($this->returnValue(Type::TYPE_SIMPLE));
+
+        $this->orderModel->expects($this->any())
+                         ->method('getAllItems')
+                         ->will(
+                             $this->returnValue(
+                                 new \ArrayIterator(
+                                     [
+                                         $childItem1,
+                                         $childItem2
+                                     ]
+                                 )
+                             )
+                         );
+
+        $expected = [
+            $this->simpleProduct1Id => [
+                'categories' => [],
+                'id' => $this->simpleProduct1Id,
+                'sku' => $this->simpleProduct1Sku,
+                'imageUrl' => '',
+                'name' => $this->simpleProduct1Name,
+                'price' => $this->simpleProduct1Price,
+                'url' => '',
+                'options' => []
+            ],
+            $this->simpleProduct2Id => [
+                'categories' => [],
+                'id' => $this->simpleProduct2Id,
+                'sku' => $this->simpleProduct2Sku,
+                'imageUrl' => '',
+                'name' => $this->simpleProduct2Name,
+                'price' => $this->simpleProduct2Price,
+                'url' => '',
+                'options' => []
+            ]
         ];
-        
+
         $result = $this->deletedProductSerializer->serialize($this->orderCollection);
-        
-//        $this->assertSame($expected, $result);
+
+        $this->assertSame($expected, $result);
     }
 }

--- a/Test/Unit/Helper/ProductImageUrlTest.php
+++ b/Test/Unit/Helper/ProductImageUrlTest.php
@@ -2,43 +2,42 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\StoreManagerInterface;
 use Metrilo\Analytics\Helper\ProductImageUrl;
+use PHPUnit\Framework\TestCase;
 
-class ProductImageUrlTest extends \PHPUnit\Framework\TestCase
+class ProductImageUrlTest extends TestCase
 {
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductImageUrl
-     */
-    private $productImageUrl;
-    
-    /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    private $storeManagerInterface;
-    
+    private ProductImageUrl $productImageUrl;
+
+    private StoreManagerInterface $storeManagerInterface;
+
     public function setUp(): void
     {
         $this->storeManagerInterface = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(array_merge(get_class_methods(StoreManagerInterface::class), ['getBaseUrl']))
             ->getMock();
-        
-        $this->productImageUrl = new ProductImageUrl($this->storeManagerInterface);
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+        $this->productImageUrl = new ProductImageUrl($this->storeManagerInterface, $context);
     }
-    
+
     public function testGetProductImageUrl()
     {
         $baseUrlString       = 'base/url/string/';
         $imageUrlRequestPath = '/image/url/request/path.jpg';
-        
+
         $this->storeManagerInterface->expects($this->any())->method('getStore')->will($this->returnSelf());
         $this->storeManagerInterface->expects($this->any())->method('getBaseUrl')
             ->with($this->equalTo('media'))->will($this->returnValue($baseUrlString));
-        
+
         $expected = $baseUrlString . 'catalog/product' . $imageUrlRequestPath;
         $result = $this->productImageUrl->getProductImageUrl($imageUrlRequestPath);
-        
+
         $this->assertEquals($expected, $result);
     }
 }

--- a/Test/Unit/Helper/ProductOptionsTest.php
+++ b/Test/Unit/Helper/ProductOptionsTest.php
@@ -4,60 +4,42 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Bundle\Model\Product\Type as Bundle;
+use Magento\Framework\App\Helper\Context;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as Grouped;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Metrilo\Analytics\Helper\ProductImageUrl;
 use Metrilo\Analytics\Helper\ProductOptions;
+use PHPUnit\Framework\TestCase;
 
-class ProductOptionsTest extends \PHPUnit\Framework\TestCase
+class ProductOptionsTest extends TestCase
 {
-    /**
-     * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable
-     */
-    private $configurableType;
-    
-    /**
-     * @var \Magento\Bundle\Model\Product\Type
-     */
-    private $bundleType;
-    
-    /**
-     * @var \Magento\GroupedProduct\Model\Product\Type\Grouped
-     */
-    private $groupedType;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductImageUrl
-     */
-    private $productImageUrlHelper;
-    
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Product\Collection
-     */
-    private $productCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductOptions
-     */
-    private $productOptions;
-    
+    private Configurable $configurableType;
+
+    private Bundle $bundleType;
+
+    private Grouped $groupedType;
+
+    private ProductImageUrl $productImageUrlHelper;
+    private Collection $productCollection;
+    private ProductOptions $productOptions;
+
     public function setUp(): void
     {
         $this->configurableType = $this->getMockBuilder(Configurable::class)
             ->disableOriginalConstructor()
             ->setMethods(['getParentIdsByChild'])
             ->getMock();
-        
+
         $this->bundleType = $this->getMockBuilder(Bundle::class)
             ->disableOriginalConstructor()
             ->setMethods(['getParentIdsByChild'])
             ->getMock();
-        
+
         $this->groupedType = $this->getMockBuilder(Grouped::class)
             ->disableOriginalConstructor()
             ->setMethods(['getParentIdsByChild'])
             ->getMock();
-        
+
         $this->productCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(array_merge(get_class_methods(Collection::class), [
@@ -71,24 +53,29 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
                 'getPrice',
                 'getName']))
             ->getMock();
-        
+
         $this->productImageUrlHelper = $this->getMockBuilder(ProductImageUrl::class)
             ->disableOriginalConstructor()
             ->setMethods(['getParentOptions', 'getProductImageUrl'])
             ->getMock();
-        
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
         $this->productOptions = new ProductOptions(
             $this->configurableType,
             $this->bundleType,
             $this->groupedType,
-            $this->productImageUrlHelper
+            $this->productImageUrlHelper,
+            $context
         );
     }
-    
+
     public function testGetParentOptions()
     {
         $imageUrl = '/product/image/url.jpg';
-        
+
         $this->productCollection->expects($this->any())->method('getTypeInstance')
             ->will($this->returnSelf());
         $this->productCollection->expects($this->any())->method('getUsedProducts')
@@ -107,11 +94,11 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('productPrice'));
         $this->productCollection->expects($this->any())->method('getName')
             ->will($this->returnValue('productName'));
-        
+
         $this->productImageUrlHelper->expects($this->any())->method('getProductImageUrl')
             ->with($this->equalTo($imageUrl))
             ->will($this->returnValue('base/url/string/' . 'catalog/product' . $imageUrl));
-        
+
         $expected[] = [
             'id'       => 1,
             'sku'      => 'productSku',
@@ -119,29 +106,29 @@ class ProductOptionsTest extends \PHPUnit\Framework\TestCase
             'price'    => 'productSpecialPrice',
             'imageUrl' => 'base/url/string/catalog/product/product/image/url.jpg'
         ];
-        
+
         $result = $this->productOptions->getParentOptions($this->productCollection);
-        
+
         $this->assertSame($expected, $result);
     }
-    
+
     public function testGetParentIds()
     {
         $productId   = 1;
         $productType = 'configurable';
-        
+
         $this->configurableType->expects($this->any())->method('getParentIdsByChild')
             ->with($this->equalTo($productId))
             ->will($this->returnValue([1,3,4]));
-        
+
         $this->bundleType->expects($this->any())->method('getParentIdsByChild')
             ->with($this->equalTo($productId))
             ->will($this->returnValue([1,3,4]));
-        
+
         $this->groupedType->expects($this->any())->method('getParentIdsByChild')
             ->with($this->equalTo($productId))
             ->will($this->returnValue([1,3,4]));
-        
+
         $this->assertEquals([1,3,4], $this->productOptions->getParentIds($productId, $productType));
     }
 }

--- a/Test/Unit/Helper/ProductSerializerTest.php
+++ b/Test/Unit/Helper/ProductSerializerTest.php
@@ -4,148 +4,137 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\StoreManagerInterface;
+use Metrilo\Analytics\Helper\ProductImageUrl;
 use Metrilo\Analytics\Helper\ProductOptions;
 use Metrilo\Analytics\Helper\ProductSerializer;
+use PHPUnit\Framework\TestCase;
 
-class ProductSerializerTest extends \PHPUnit\Framework\TestCase
+class ProductSerializerTest extends TestCase
 {
-    /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    private $storeManager;
-    
-    /**
-     * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable
-     */
-    private $configurableType;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductImageUrl
-     */
-    private $productImageUrlHelper;
-    
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Product\Collection
-     */
-    private $productCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductOptions
-     */
-    private $productOptions;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductSerializer
-     */
-    private $productSerializer;
-    
+    private StoreManagerInterface $storeManager;
+
+    private ProductImageUrl $productImageUrlHelper;
+
+    private Collection $productCollection;
+
+    private ProductOptions $productOptions;
+
+    private ProductSerializer $productSerializer;
+
     public function setUp(): void
     {
         $this->productCollection = $this->getMockBuilder(Collection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(array_merge(get_class_methods(Collection::class), [
-                'getId',
-                'getTypeId',
-                'getImage',
-                'getPrice',
-                'getSpecialPrice',
-                'getRequestPath',
-                'getCategoryIds',
-                'getSku',
-                'getName'
-            ]))
-            ->getMock();
-        
+                                        ->disableOriginalConstructor()
+                                        ->setMethods(
+                                            array_merge(get_class_methods(Collection::class), [
+                                                'getId',
+                                                'getTypeId',
+                                                'getImage',
+                                                'getPrice',
+                                                'getSpecialPrice',
+                                                'getRequestPath',
+                                                'getCategoryIds',
+                                                'getSku',
+                                                'getName'
+                                            ])
+                                        )
+                                        ->getMock();
+
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(array_merge(get_class_methods(StoreManagerInterface::class), ['getBaseUrl']))
-            ->getMock();
-        
-        $this->configurableType = $this->getMockBuilder(Configurable::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentIdsByChild'])
-            ->getMock();
-        
+                                   ->disableOriginalConstructor()
+                                   ->setMethods(
+                                       array_merge(get_class_methods(StoreManagerInterface::class), ['getBaseUrl'])
+                                   )
+                                   ->getMock();
+
         $this->productImageUrlHelper = $this->getMockBuilder(ProductImageUrl::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentOptions', 'getProductImageUrl'])
-            ->getMock();
-        
+                                            ->disableOriginalConstructor()
+                                            ->setMethods(['getParentOptions', 'getProductImageUrl'])
+                                            ->getMock();
+
         $this->productOptions = $this->getMockBuilder(ProductOptions::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentIds', 'getParentOptions'])
-            ->getMock();
-        
-        $this->productSerializer = new ProductSerializer($this->storeManager, $this->productOptions);
+                                     ->disableOriginalConstructor()
+                                     ->setMethods(['getParentIds', 'getParentOptions'])
+                                     ->getMock();
+
+        $context = $this->getMockBuilder(Context::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $this->productSerializer = new ProductSerializer(
+            $this->storeManager,
+            $this->productOptions,
+            $this->productImageUrlHelper,
+            $context
+        );
     }
-    
+
     public function testSerialize()
     {
-        $storeId        = 1;
-        $productId      = 1;
-        $productSku     = 'productSku';
-        $productName    = 'productName';
+        $storeId = 1;
+        $productId = 1;
+        $productSku = 'productSku';
+        $productName = 'productName';
         $productOptions = [];
-        
-        $baseUrl        = 'base/url/string/';
-        $imageUrl       = '/product/image/url.jpg';
-        $requestPath    = 'product/request/path.html';
-        
+
+        $baseUrl = 'base/url/string/';
+        $imageUrl = '/product/image/url.jpg';
+        $requestPath = 'product/request/path.html';
+
         $this->productCollection->expects($this->any())->method('getStoreId')
-            ->will($this->returnValue($storeId));
+                                ->will($this->returnValue($storeId));
         $this->productCollection->expects($this->any())->method('getId')
-            ->will($this->returnValue($productId));
-        $this->productCollection->expects($this->at(0))->method('getTypeId')
-            ->will($this->returnValue('simple'));
-        $this->productCollection->expects($this->at(1))->method('getTypeId')
-            ->will($this->returnValue('configurable'));
+                                ->will($this->returnValue($productId));
+        $this->productCollection->expects($this->any())->method('getTypeId')
+                                ->willReturnOnConsecutiveCalls(['simple'], ['configurable']);
+
         $this->productCollection->expects($this->any())->method('getImage')
-            ->will($this->returnValue($imageUrl));
+                                ->will($this->returnValue($imageUrl));
         $this->productCollection->expects($this->any())->method('getPrice')
-            ->will($this->returnValue('productPrice'));
+                                ->will($this->returnValue('productPrice'));
         $this->productCollection->expects($this->any())->method('getSpecialPrice')
-            ->will($this->returnValue('productSpecialPrice'));
+                                ->will($this->returnValue('productSpecialPrice'));
         $this->productCollection->expects($this->any())->method('getRequestPath')
-            ->will($this->returnValue($requestPath));
+                                ->will($this->returnValue($requestPath));
         $this->productCollection->expects($this->any())->method('getCategoryIds')
-            ->will($this->returnValue([1,3,4]));
+                                ->will($this->returnValue([1, 3, 4]));
         $this->productCollection->expects($this->any())->method('getSku')
-            ->will($this->returnValue($productSku));
+                                ->will($this->returnValue($productSku));
         $this->productCollection->expects($this->any())->method('getName')
-            ->will($this->returnValue($productName));
-        
+                                ->will($this->returnValue($productName));
+
         $this->productOptions->expects($this->any())->method('getParentOptions')
-            ->with($this->isInstanceOf(Collection::class))
-            ->will($this->returnValue($productOptions));
+                             ->with($this->isInstanceOf(Collection::class))
+                             ->will($this->returnValue($productOptions));
         $this->productOptions->expects($this->any())->method('getParentIds')
-            ->with($this->equalTo($productId))
-            ->will($this->returnValue($productOptions));
-        $this->productOptions->productImageUrl = $this->productImageUrlHelper;
-        
+                             ->with($this->equalTo($productId))
+                             ->will($this->returnValue($productOptions));
+
         $this->productImageUrlHelper->expects($this->any())->method('getProductImageUrl')
-            ->with($this->equalTo($imageUrl))
-            ->will($this->returnValue($baseUrl . 'catalog/product' . $imageUrl));
-        
+                                    ->with($this->equalTo($imageUrl))
+                                    ->will($this->returnValue($baseUrl . 'catalog/product' . $imageUrl));
+
         $this->storeManager->expects($this->any())->method('getStore')
-            ->with($this->equalTo($storeId))
-            ->will($this->returnSelf());
+                           ->with($this->equalTo($storeId))
+                           ->will($this->returnSelf());
         $this->storeManager->expects($this->any())->method('getBaseUrl')
-            ->will($this->returnValue($baseUrl));
-        
+                           ->will($this->returnValue($baseUrl));
+
         $expected = [
-            'categories' => [1,3,4],
-            'id'         => 1,
-            'sku'        => $productSku,
-            'imageUrl'   => $baseUrl . 'catalog/product' . $imageUrl,
-            'name'       => $productName,
-            'price'      => 'productSpecialPrice',
-            'url'        => $baseUrl . $requestPath,
-            'options'    => $productOptions
+            'categories' => [1, 3, 4],
+            'id' => 1,
+            'sku' => $productSku,
+            'imageUrl' => $baseUrl . 'catalog/product' . $imageUrl,
+            'name' => $productName,
+            'price' => 'productSpecialPrice',
+            'url' => $baseUrl . $requestPath,
+            'options' => $productOptions
         ];
-        
+
         $result = $this->productSerializer->serialize($this->productCollection);
-        
+
         $this->assertEquals($expected, $result);
     }
 }

--- a/Test/Unit/Helper/SessionEventsTest.php
+++ b/Test/Unit/Helper/SessionEventsTest.php
@@ -3,46 +3,45 @@
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Catalog\Model\Session;
+use Magento\Framework\App\Helper\Context;
 use Metrilo\Analytics\Helper\SessionEvents;
+use PHPUnit\Framework\TestCase;
 
-class SessionEventsTest extends \PHPUnit\Framework\TestCase
+class SessionEventsTest extends TestCase
 {
-    /**
-     * @var \Magento\Catalog\Model\Session
-     */
-    private $session;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEvents;
-    
-    private $metriloSessionEvents = 'metrilo_session_key';
-    
+    private Session $session;
+    private SessionEvents $sessionEvents;
+
+    private string $metriloSessionEvents = 'metrilo_session_key';
+
     public function setUp(): void
     {
-        
+
         $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
             ->setMethods(['getData', 'setData'])
             ->getMock();
-        
-        $this->sessionEvents = new SessionEvents($this->session);
+
+        $context = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->sessionEvents = new SessionEvents($this->session, $context);
     }
-    
+
     public function testGetSessionEvents()
     {
         $this->session->expects($this->any())->method('getData')
             ->with($this->equalTo($this->metriloSessionEvents), $this->equalTo(true));
-        
+
         $this->assertEquals([], $this->sessionEvents->getSessionEvents());
     }
-    
+
     public function testAddSessionEvent()
     {
         $this->session->expects($this->any())->method('setData')
             ->with($this->equalTo($this->metriloSessionEvents), $this->isType('array'));
-        
+
         $this->assertEquals([], $this->sessionEvents->getSessionEvents());
     }
 }

--- a/Test/Unit/Model/DeletedProductDataTest.php
+++ b/Test/Unit/Model/DeletedProductDataTest.php
@@ -2,89 +2,84 @@
 
 namespace Metrilo\Analytics\Test\Unit\Model;
 
+use Magento\Sales\Model\ResourceModel\Order\Collection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollection;
 use Magento\Sales\Model\ResourceModel\Order\Item\Collection as OrderItemCollection;
 use Metrilo\Analytics\Model\DeletedProductData;
+use PHPUnit\Framework\TestCase;
 
-class DeletedProductDataTest extends \PHPUnit\Framework\TestCase
+class DeletedProductDataTest extends TestCase
 {
-    /**
-     * @var DeletedProductData
-     */
-    private $deletedProductData;
-    
-    /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\Collection
-     */
-    private $orderCollection;
-    
-    /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\Item\Collection
-     */
-    private $orderItemCollection;
-    
+    private DeletedProductData $deletedProductData;
+
+    private OrderCollection $orderCollection;
+
+    private OrderItemCollection $orderItemCollection;
+
     /**
      * @var \Magento\Framework\App\Request\Http->getParam('store', 0)
      */
-    private $storeId = 1;
-    
+    private int $storeId = 1;
+
     public function setUp(): void
     {
         $this->orderCollection = $this->getMockBuilder(OrderCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create','addFieldToFilter'])
-            ->getMock();
-        
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['create', 'addFieldToFilter'])
+                                      ->getMock();
+
         $this->orderItemCollection = $this->getMockBuilder(OrderItemCollection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(array_merge(get_class_methods(OrderItemCollection::class), [
-                'reset',
-                'columns',
-                'joinLeft',
-                'where',
-                'fetchAll']))
-            ->getMock();
-       
+                                          ->disableOriginalConstructor()
+                                          ->setMethods(
+                                              array_merge(get_class_methods(OrderItemCollection::class), [
+                                                  'reset',
+                                                  'columns',
+                                                  'joinLeft',
+                                                  'where',
+                                                  'fetchAll'
+                                              ])
+                                          )
+                                          ->getMock();
+
         $this->deletedProductData = new DeletedProductData($this->orderCollection, $this->orderItemCollection);
     }
-    
+
     public function testGetDeletedProductOrders()
     {
         $this->orderItemCollection->expects($this->any())->method('getSelect')
-            ->will($this->returnSelf());
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('distinct')
-            ->with($this->isType('bool'))
-            ->will($this->returnSelf());
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('reset')
-            ->with($this->isType('string'))
-            ->will($this->returnSelf());
+                                  ->with($this->isType('string'))
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('columns')
-            ->with($this->isType('array'))
-            ->will($this->returnSelf());
+                                  ->with($this->isType('array'))
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('joinLeft')
-            ->with($this->isType('array'), $this->isType('string'), $this->isType('array'))
-            ->will($this->returnSelf());
+                                  ->with($this->isType('array'), $this->isType('string'), $this->isType('array'))
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('where')
-            ->withConsecutive(
-                [$this->isType('string')],
-                [$this->isType('string'), $this->isType('int')]
-            )
-            ->will($this->returnSelf());
+                                  ->withConsecutive(
+                                      [$this->isType('string')],
+                                      [$this->isType('string'), $this->isType('int')]
+                                  )
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('getConnection')
-            ->will($this->returnSelf());
+                                  ->will($this->returnSelf());
         $this->orderItemCollection->expects($this->any())->method('fetchAll')
-            ->with($this->isInstanceOf(OrderItemCollection::class))
-            ->will($this->returnValue([1,2,3]));
-    
+                                  ->with($this->isInstanceOf(OrderItemCollection::class))
+                                  ->will($this->returnValue([1, 2, 3]));
+
         $deletedProductOrderIds = $this->orderItemCollection->getConnection()->fetchAll($this->orderItemCollection);
-        $this->assertEquals([1,2,3], $deletedProductOrderIds);
-        
+        $this->assertEquals([1, 2, 3], $deletedProductOrderIds);
+
         $this->orderCollection->expects($this->any())->method('create')
-            ->will($this->returnSelf());
+                              ->will($this->returnSelf());
         $this->orderCollection->expects($this->any())->method('addFieldToFilter')
-            ->with($this->isType('string'), $this->isType('array'))
-            ->will($this->returnSelf());
-        
+                              ->with($this->isType('string'), $this->isType('array'))
+                              ->will($this->returnSelf());
+
         $this->assertInstanceOf(
             OrderCollection::class,
             $this->deletedProductData->getDeletedProductOrders($this->storeId)

--- a/Test/Unit/Model/Events/CatalogSearchTest.php
+++ b/Test/Unit/Model/Events/CatalogSearchTest.php
@@ -5,51 +5,40 @@ namespace Metrilo\Analytics\Test\Unit\Model\Events;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\App\Request\Http;
 use Metrilo\Analytics\Model\Events\CatalogSearch;
+use PHPUnit\Framework\TestCase;
 
-class CatalogSearchTest extends \PHPUnit\Framework\TestCase
+class CatalogSearchTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\UrlInterface
-     */
-    private $urlInterface;
+    private Http $request;
 
-    /**
-     * @var \Magento\Framework\App\Request\Http
-     */
-    private $request;
+    private CatalogSearch $catalogSearchEvent;
 
-    /**
-     * @var \Metrilo\Analytics\Model\Events\CatalogSearch
-     */
-    private $catalogSearchEvent;
-    
-    private $pageUrl     = 'http://website.domain/product.html';
-    private $searchQuery = 'search_query';
+    private string $pageUrl = 'http://website.domain/product.html';
+
+    private string $searchQuery = 'search_query';
 
     public function setUp(): void
     {
-        $this->urlInterface = $this->getMockBuilder(UrlInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCurrentUrl'])
-            ->getMockForAbstractClass();
-    
-        $this->urlInterface->expects($this->any())->method('getCurrentUrl')
-            ->will($this->returnValue($this->pageUrl));
+        $urlInterface = $this->getMockBuilder(UrlInterface::class)
+                             ->disableOriginalConstructor()
+                             ->setMethods(['getCurrentUrl'])
+                             ->getMockForAbstractClass();
+
+        $urlInterface->expects($this->any())->method('getCurrentUrl')
+                           ->will($this->returnValue($this->pageUrl));
 
         $this->request = $this->getMockBuilder(Http::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
-            ->getMock();
+                              ->disableOriginalConstructor()
+                              ->getMock();
 
-        $this->catalogSearchEvent = new CatalogSearch($this->urlInterface, $this->request);
+        $this->catalogSearchEvent = new CatalogSearch($urlInterface, $this->request);
     }
 
     public function testCallJsForAdvancedSearch()
     {
-
         $this->request->expects($this->any())->method('getParam')
-            ->with($this->equalTo('q'))
-            ->will($this->returnValue($this->searchQuery));
+                      ->with($this->equalTo('q'))
+                      ->will($this->returnValue($this->searchQuery));
 
         $expected = "window.metrilo.search('" . $this->searchQuery . "', '" . $this->pageUrl . "');";
 
@@ -57,21 +46,16 @@ class CatalogSearchTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($expected, $result);
     }
-    
+
     public function testCallJsForStandardSearch()
     {
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with($this->equalTo('q'))
-            ->will($this->returnValue(''));
-        
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with($this->equalTo('name'))
-            ->will($this->returnValue($this->searchQuery));
-    
+        $this->request->expects($this->any())->method('getParam')
+                      ->willReturnOnConsecutiveCalls('', $this->searchQuery);
+
         $expected = "window.metrilo.search('" . $this->searchQuery . "', '" . $this->pageUrl . "');";
-    
+
         $result = $this->catalogSearchEvent->callJS();
-    
+
         $this->assertSame($expected, $result);
     }
 }

--- a/Test/Unit/Model/Events/PageViewTest.php
+++ b/Test/Unit/Model/Events/PageViewTest.php
@@ -2,56 +2,48 @@
 
 namespace Metrilo\Analytics\Test\Unit\Model\Events;
 
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Page\Title;
 use Magento\Framework\UrlInterface;
 use Metrilo\Analytics\Model\Events\PageView;
+use PHPUnit\Framework\TestCase;
 
-class PageViewTest extends \PHPUnit\Framework\TestCase
+class PageViewTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\View\Page\Title
-     */
-    private $pageTitleView;
-    
-    /**
-     * @var \Magento\Framework\UrlInterface
-     */
-    private $urlInterface;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\PageView
-     */
-    private $pageViewEvent;
-    
-    private $pageTitle = 'pageTitle';
-    private $pageUrl   = 'http://website.domain/product.html';
-    
+    private Title $pageTitleView;
+    private UrlInterface $urlInterface;
+    private PageView $pageViewEvent;
+    private Json $json;
+    private string $pageTitle = 'pageTitle';
+    private string $pageUrl = 'http://website.domain/product.html';
+
     public function setUp(): void
     {
         $this->pageTitleView = $this->getMockBuilder(Title::class)
             ->disableOriginalConstructor()
             ->setMethods(['getShort'])
             ->getMock();
-        
+
         $this->urlInterface = $this->getMockBuilder(UrlInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getCurrentUrl'])
             ->getMockForAbstractClass();
-        
-        $this->pageViewEvent = new PageView($this->pageTitleView, $this->urlInterface);
+        $this->json = new Json();
+
+        $this->pageViewEvent = new PageView($this->pageTitleView, $this->urlInterface, $this->json);
     }
-    
+
     public function testCallJs()
     {
         $this->pageTitleView->expects($this->any())->method('getShort')->will($this->returnValue($this->pageTitle));
-    
+
         $this->urlInterface->expects($this->any())->method('getCurrentUrl')->will($this->returnValue($this->pageUrl));
-        
+
         $expected = "window.metrilo.viewPage('" . $this->pageUrl . "', " .
-                    json_encode(array('name' => $this->pageTitle)) . ");";
-        
+                    $this->json->serialize(['name' => $this->pageTitle]) . ");";
+
         $result = $this->pageViewEvent->callJS();
-        
+
         $this->assertSame($expected, $result);
     }
 }

--- a/Test/Unit/Model/OrderDataTest.php
+++ b/Test/Unit/Model/OrderDataTest.php
@@ -4,33 +4,23 @@ namespace Metrilo\Analytics\Test\Unit\Model;
 
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Metrilo\Analytics\Model\OrderData;
+use PHPUnit\Framework\TestCase;
 
-class OrderDataTest extends \PHPUnit\Framework\TestCase
+class OrderDataTest extends TestCase
 {
-    /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\Collection
-     */
-    private $orderCollection;
+    private CollectionFactory $orderCollection;
 
-    /**
-     * @var OrderData
-     */
-    private $orderData;
-
-    /**
-     * @var \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS
-     */
-    private $chunkItems = 50;
+    private OrderData $orderData;
 
     /**
      * @var \Magento\Framework\App\Request\Http->getParam('store', 0)
      */
-    private $storeId = 1;
+    private int $storeId = 1;
 
     /**
      * @var \Magento\Framework\App\Request\Http->getParam('chunkId')
      */
-    private $chunkId = 1;
+    private int $chunkId = 1;
 
     public function setUp(): void
     {

--- a/Test/Unit/Model/ProductDataTest.php
+++ b/Test/Unit/Model/ProductDataTest.php
@@ -23,11 +23,6 @@ class ProductDataTest extends \PHPUnit\Framework\TestCase
     private $productId = 1;
 
     /**
-     * @var \Metrilo\Analytics\Helper\Data::CHUNK_ITEMS
-     */
-    private $chunkItems = 50;
-
-    /**
      * @var \Magento\Framework\App\Request\Http->getParam('store', 0)
      */
     private $storeId = 1;

--- a/Test/Unit/Observer/AddToCartTest.php
+++ b/Test/Unit/Observer/AddToCartTest.php
@@ -2,99 +2,89 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Catalog\Model\Session;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\SessionEvents;
 use Metrilo\Analytics\Model\Events\AddToCart as AddToCartEvent;
+use Metrilo\Analytics\Model\Events\AddToCartFactory;
 use Metrilo\Analytics\Observer\AddToCart;
+use PHPUnit\Framework\TestCase;
 
-class AddToCartTest extends \PHPUnit\Framework\TestCase
+class AddToCartTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Magento\Catalog\Model\Session
-     */
-    private $catalogSession;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEvents;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\AddToCart
-     */
-    private $addToCartEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\AddToCart
-     */
-    private $addToCartObserver;
-    
+    private Observer $observer;
+
+    private Data $dataHelper;
+
+    private SessionEvents $sessionEvents;
+
+    private AddToCart $addToCartObserver;
+
+    private AddToCartFactory $addToCartFactory;
+
     public function setUp(): void
     {
-        
+
         $this->observer = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
             ->setMethods(['getEvent', 'getProduct', 'getStoreId', 'getQuoteItem'])
             ->getMock();
-    
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
             ->setMethods(['isEnabled', 'logError'])
             ->getMock();
-    
-        $this->catalogSession = $this->getMockBuilder(Session::class)
+
+        $catalogSession = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
             ->getMock();
-        
+        $context = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()->getMock();
+
         $this->sessionEvents = $this->getMockBuilder(SessionEvents::class)
-            ->setConstructorArgs([$this->catalogSession])
+            ->setConstructorArgs([$catalogSession, $context])
             ->setMethods(['getData', 'setData'])
             ->getMock();
-    
-        $this->addToCartEvent = $this->getMockBuilder(AddToCart::class)
+
+        $addToCartEvent = $this->getMockBuilder(AddToCartEvent::class)
             ->disableOriginalConstructor()
-            ->setMethods(['execute'])
+            ->setMethods(['callJS'])
             ->getMock();
-    
-        $this->addToCartObserver = new AddToCart($this->dataHelper, $this->sessionEvents);
+
+        $this->addToCartFactory = $this->getMockBuilder(AddToCartFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->addToCartFactory->method('create')->will($this->returnValue($addToCartEvent));
+
+        $this->addToCartObserver = new AddToCart($this->dataHelper, $this->sessionEvents, $this->addToCartFactory);
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
             ObserverInterface::class,
-            new AddToCart($this->dataHelper, $this->sessionEvents)
+            new AddToCart($this->dataHelper, $this->sessionEvents, $this->addToCartFactory)
         );
     }
-    
+
     public function testExecute()
     {
         $storeId = 1;
-        
+
         $this->observer->expects($this->any())->method('getEvent')->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getProduct')->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getStoreId')->will($this->returnValue($storeId));
         $this->observer->expects($this->any())->method('getQuoteItem')->will($this->returnSelf());
-    
+
         $this->dataHelper->expects($this->any())->method('isEnabled')->with($this->isType('int'))
             ->will($this->returnValue(true));
         $this->dataHelper->expects($this->any())->method('logError')->with($this->isType('object'));
-    
+
         $this->addToCartObserver->execute($this->observer);
-        
+
         $this->assertEquals([], $this->sessionEvents->getSessionEvents());
     }
 }

--- a/Test/Unit/Observer/ConfigTest.php
+++ b/Test/Unit/Observer/ConfigTest.php
@@ -5,83 +5,104 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Website;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\Activity;
 use Metrilo\Analytics\Observer\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit\Framework\TestCase
+class ConfigTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Magento\Framework\Message\ManagerInterface
-     */
-    private $managerInterface;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Activity
-     */
-    private $activityHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\Config
-     */
-    private $configObserver;
-    
+    private Observer $observer;
+
+    private ManagerInterface $managerInterface;
+
+    private Data $dataHelper;
+
+    private Activity $activityHelper;
+
+    private Config $configObserver;
+
+    private StoreManagerInterface $storeManager;
+
     public function setUp(): void
     {
         $this->observer = $this->getMockBuilder(Observer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getStore'])
-            ->getMock();
-    
+                               ->disableOriginalConstructor()
+                               ->setMethods(['getStore', 'getWebsite'])
+                               ->getMock();
+
         $this->managerInterface = $this->getMockBuilder(ManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(get_class_methods(ManagerInterface::class))
-            ->getMock();
-    
+                                       ->disableOriginalConstructor()
+                                       ->setMethods(get_class_methods(ManagerInterface::class))
+                                       ->getMock();
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['logError'])
-            ->getMock();
-    
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['logError'])
+                                 ->getMock();
+
         $this->activityHelper = $this->getMockBuilder(Activity::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['createActivity'])
-            ->getMock();
-        
-        
-        $this->configObserver = new Config($this->managerInterface, $this->dataHelper, $this->activityHelper);
+                                     ->disableOriginalConstructor()
+                                     ->setMethods(['createActivity'])
+                                     ->getMock();
+
+        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
+                                   ->disableOriginalConstructor()
+                                   ->getMock();
+
+        $this->configObserver = new Config(
+            $this->managerInterface,
+            $this->dataHelper,
+            $this->activityHelper,
+            $this->storeManager
+        );
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
             ObserverInterface::class,
-            new Config($this->managerInterface, $this->dataHelper, $this->activityHelper)
+            new Config($this->managerInterface, $this->dataHelper, $this->activityHelper, $this->storeManager)
         );
     }
-    
+
     public function testExecute()
     {
         $storeId = 1;
-    
-        $this->observer->expects($this->any())->method('getStore')->will($this->returnValue($storeId));
-        
+
+        $this->observer->expects($this->once())->method('getStore')->will($this->returnValue(''));
+        $this->observer->expects($this->exactly(2))->method('getWebsite')
+                       ->will($this->returnValue(1));
+
+        $website = $this->getMockBuilder(Website::class)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+        $store = $this->getMockBuilder(Store::class)
+                      ->disableOriginalConstructor()
+                      ->getMock();
+
+        $this->storeManager->expects($this->once())
+                           ->method('getWebsite')
+                           ->with(1)
+                           ->will($this->returnValue($website));
+
+        $website->expects($this->once())
+                ->method('getDefaultStore')
+                ->will($this->returnValue($store));
+
+        $store->expects($this->once())
+              ->method('getId')
+              ->will($this->returnValue($storeId));
+
         $this->managerInterface->expects($this->any())->method('addError')->with($this->isType('string'));
-        
-        $this->activityHelper->expects($this->any())->method('createActivity')
-            ->with($this->isType('int'), $this->isType('string'))
-            ->will($this->returnValue(false));
-        
+
+        $this->activityHelper->expects($this->once())->method('createActivity')
+                             ->with($storeId, 'integrated')
+                             ->will($this->returnValue(false));
+
         $this->configObserver->execute($this->observer);
     }
 }

--- a/Test/Unit/Observer/CustomerTest.php
+++ b/Test/Unit/Observer/CustomerTest.php
@@ -11,148 +11,133 @@ use Metrilo\Analytics\Api\Client;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\ApiClient;
 use Metrilo\Analytics\Helper\CustomerSerializer;
-use Metrilo\Analytics\Helper\MetriloCustomer;
+use Metrilo\Analytics\Model\Events\CustomEventFactory;
+use Metrilo\Analytics\Model\Events\IdentifyCustomerFactory;
+use Metrilo\Analytics\Model\MetriloCustomer;
+use Metrilo\Analytics\Model\MetriloCustomerFactory;
 use Metrilo\Analytics\Observer\Customer;
 use Metrilo\Analytics\Helper\SessionEvents;
 use Metrilo\Analytics\Model\Events\CustomEvent;
-use Metrilo\Analytics\Model\IdentifyCustomer;
+use Metrilo\Analytics\Model\Events\IdentifyCustomer;
+use PHPUnit\Framework\TestCase;
 
-class CustomerTest extends \PHPUnit\Framework\TestCase
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class CustomerTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Magento\Customer\Api\CustomerRepositoryInterface
-     */
-    private $customerRepositoryInterface;
-    
-    /**
-     * @var \Magento\Customer\Api\GroupRepositoryInterface
-     */
-    private $groupRepositoryInterface;
-    
-    /**
-     * @var \Magento\Newsletter\Model\Subscriber
-     */
-    private $subscriberModel;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ApiClient
-     */
-    private $apiClientHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Api\Client
-     */
-    private $client;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\CustomerSerializer
-     */
-    private $customerSerializerHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\MetriloCustomer
-     */
-    private $customerHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\Customer
-     */
-    private $customerObserver;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\IdentifyCustomer
-     */
-    private $identifyEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\CustomEvent
-     */
-    private $customEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEvents;
-    
+    private Observer $observer;
+
+    private CustomerRepositoryInterface $customerRepositoryInterface;
+
+    private GroupRepositoryInterface $groupRepositoryInterface;
+
+    private Subscriber $subscriberModel;
+
+    private Data $dataHelper;
+
+    private ApiClient $apiClientHelper;
+
+    private Client $client;
+
+    private CustomerSerializer $customerSerializerHelper;
+
+    private Customer $customerObserver;
+
+    private SessionEvents $sessionEvents;
+
+    private MetriloCustomerFactory $customerFactory;
+
+    private CustomEventFactory $customEventFactory;
+
+    private IdentifyCustomerFactory $identifyCustomerFactory;
+
     public function setUp(): void
     {
         $this->observer = $this->getMockBuilder(Observer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEvent', 'getCustomer', 'getName', 'getSubscriber'])
-            ->getMock();
-    
+                               ->disableOriginalConstructor()
+                               ->setMethods(['getEvent', 'getCustomer', 'getName', 'getSubscriber'])
+                               ->getMock();
+
         $this->customerRepositoryInterface = $this->getMockBuilder(CustomerRepositoryInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['save', 'getList', 'delete', 'deleteById', 'getById', 'get'])
-            ->getMock();
-    
+                                                  ->disableOriginalConstructor()
+                                                  ->setMethods(
+                                                      ['save', 'getList', 'delete', 'deleteById', 'getById', 'get']
+                                                  )
+                                                  ->getMock();
+
         $this->groupRepositoryInterface = $this->getMockBuilder(GroupRepositoryInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['save', 'getList', 'delete', 'deleteById', 'getById'])
-            ->getMock();
-    
+                                               ->disableOriginalConstructor()
+                                               ->setMethods(['save', 'getList', 'delete', 'deleteById', 'getById'])
+                                               ->getMock();
+
         $this->subscriberModel = $this->getMockBuilder(Subscriber::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['unsetData', 'loadByCustomerId', 'isSubscribed', ])
-            ->getMock();
-        
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['unsetData', 'loadByCustomerId', 'isSubscribed',])
+                                      ->getMock();
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isEnabled', 'logError'])
-            ->getMock();
-        
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['isEnabled', 'logError'])
+                                 ->getMock();
+
         $this->apiClientHelper = $this->getMockBuilder(ApiClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getClient'])
-            ->getMock();
-    
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['getClient'])
+                                      ->getMock();
+
         $this->client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['customer'])
-            ->getMock();
-    
+                             ->disableOriginalConstructor()
+                             ->setMethods(['customer'])
+                             ->getMock();
+
         $this->customerSerializerHelper = $this->getMockBuilder(CustomerSerializer::class)
-            ->disableOriginalConstructor()
-//            ->setMethods(['logError'])
-            ->getMock();
-        
-        $this->customerHelper = $this->getMockBuilder(MetriloCustomer::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'getStoreId',
-                'getEmail',
-                'getCreatedAt',
-                'getFirstName',
-                'getLastName',
-                'getSubscriberStatus',
-                'getTags'])
-            ->getMock();
-    
-        $this->identifyEvent = $this->getMockBuilder(IdentifyCustomer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
-        $this->customEvent = $this->getMockBuilder(CustomEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-    
+                                               ->disableOriginalConstructor()
+                                               ->getMock();
+
+        $customer = $this->getMockBuilder(MetriloCustomer::class)
+                         ->disableOriginalConstructor()
+                         ->setMethods([
+                             'getStoreId',
+                             'getEmail',
+                             'getCreatedAt',
+                             'getFirstName',
+                             'getLastName',
+                             'getSubscriberStatus',
+                             'getTags'
+                         ])
+                         ->getMock();
+
+        $this->customerFactory = $this->getMockBuilder(MetriloCustomerFactory::class)
+                                      ->disableOriginalConstructor()
+                                      ->getMock();
+        $this->customerFactory->method('create')->will($this->returnValue($customer));
+
+        $identifyEvent = $this->getMockBuilder(IdentifyCustomer::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['callJs'])
+                              ->getMock();
+
+        $this->identifyCustomerFactory = $this->getMockBuilder(IdentifyCustomerFactory::class)
+                                              ->disableOriginalConstructor()
+                                              ->getMock();
+        $this->identifyCustomerFactory->method('create')->will($this->returnValue($identifyEvent));
+
+        $customEvent = $this->getMockBuilder(CustomEvent::class)
+                            ->disableOriginalConstructor()
+                            ->setMethods(['callJs'])
+                            ->getMock();
+
+        $this->customEventFactory = $this->getMockBuilder(CustomEventFactory::class)
+                                         ->disableOriginalConstructor()
+                                         ->getMock();
+        $this->customEventFactory->method('create')->will($this->returnValue($customEvent));
+
         $this->sessionEvents = $this->getMockBuilder(SessionEvents::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addSessionEvent'])
-            ->getMock();
-        
+                                    ->disableOriginalConstructor()
+                                    ->setMethods(['addSessionEvent'])
+                                    ->getMock();
+
         $this->customerObserver = new Customer(
             $this->dataHelper,
             $this->apiClientHelper,
@@ -160,10 +145,13 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
             $this->customerRepositoryInterface,
             $this->subscriberModel,
             $this->groupRepositoryInterface,
-            $this->sessionEvents
+            $this->sessionEvents,
+            $this->customerFactory,
+            $this->identifyCustomerFactory,
+            $this->customEventFactory
         );
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
@@ -175,51 +163,54 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
                 $this->customerRepositoryInterface,
                 $this->subscriberModel,
                 $this->groupRepositoryInterface,
-                $this->sessionEvents
+                $this->sessionEvents,
+                $this->customerFactory,
+                $this->identifyCustomerFactory,
+                $this->customEventFactory
             )
         );
     }
-    
+
     public function testExecute()
     {
         $storeId = 1;
-        
+
         $this->observer->expects($this->any())->method('getEvent')
-            ->will($this->returnSelf());
+                       ->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getSubscriber')
-            ->will($this->returnValue($this->subscriberModel));
-        $this->observer->expects($this->at(0))->method('getName')
-            ->will($this->returnValue('customer_save_after'));
-        $this->observer->expects($this->at(1))->method('getName')
-            ->will($this->returnValue('newsletter_subscriber_save_after'));
-        $this->observer->expects($this->at(2))->method('getName')
-            ->will($this->returnValue('customer_account_edited'));
-        $this->observer->expects($this->at(3))->method('getName')
-            ->will($this->returnValue('customer_register_success'));
-    
-        $this->sessionEvents->expects($this->any())->method('addSessionEvent')
-            ->with(
-                self::logicalOr(
-                    $this->isInstanceOf(IdentifyCustomer::class),
-                    $this->isInstanceOf(CustomEvent::class)
-                )
+                       ->will($this->returnValue($this->subscriberModel));
+
+        $this->observer->expects($this->any())->method('getName')
+            ->willReturnOnConsecutiveCalls(
+                ['customer_save_after'],
+                ['newsletter_subscriber_save_after'],
+                ['customer_account_edited'],
+                ['customer_register_success']
             );
-        
+
+        $this->sessionEvents->expects($this->any())->method('addSessionEvent')
+                            ->with(
+                                self::logicalOr(
+                                    $this->isInstanceOf(IdentifyCustomer::class),
+                                    $this->isInstanceOf(CustomEvent::class)
+                                )
+                            );
+
         $this->dataHelper->expects($this->any())->method('isEnabled')->with($this->isType('int'))
-            ->will($this->returnValue(true));
+                         ->will($this->returnValue(true));
         $this->dataHelper->expects($this->any())->method('logError')->with($this->isType('object'));
-    
+
         $this->apiClientHelper->expects($this->any())->method('getClient')
-            ->with($this->equalTo($storeId))
-            ->will($this->returnValue($this->client));
-    
+                              ->with($this->equalTo($storeId))
+                              ->will($this->returnValue($this->client));
+
         $this->client->expects($this->any())->method('customer')
-            ->with($this->isInstanceOf(CustomerSerializer::class));
-    
+                     ->with($this->isInstanceOf(CustomerSerializer::class));
+
         $this->customerSerializerHelper->expects($this->any())->method('serialize')
-            ->with($this->isInstanceOf(CustomerSerializer::class))
-            ->will($this->returnValue([]));
-        
+                                       ->with($this->isInstanceOf(CustomerSerializer::class))
+                                       ->will($this->returnValue([]));
+
         $this->customerObserver->execute($this->observer);
     }
 }

--- a/Test/Unit/Observer/IdentifyCustomerTest.php
+++ b/Test/Unit/Observer/IdentifyCustomerTest.php
@@ -4,94 +4,88 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Metrilo\Analytics\Model\Events\IdentifyCustomer as IdentifyCustomerEvent;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Helper\SessionEvents;
+use Metrilo\Analytics\Model\Events\IdentifyCustomer as IdentifyCustomerEvent;
+use Metrilo\Analytics\Model\Events\IdentifyCustomerFactory;
 use Metrilo\Analytics\Observer\IdentifyCustomer;
+use PHPUnit\Framework\TestCase;
 
-class IdentifyCustomerTest extends \PHPUnit\Framework\TestCase
+class IdentifyCustomerTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\IdentifyCustomer
-     */
-    private $identifyCustomerEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEvents;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\Customer
-     */
-    private $identifyCustomerObserver;
-    
+    private Observer $observer;
+
+    private Data $dataHelper;
+
+    private SessionEvents $sessionEvents;
+
+    private IdentifyCustomer $identifyCustomerObserver;
+
+    private IdentifyCustomerFactory $identifyCustomerFactory;
+
     public function setUp(): void
     {
         $this->observer = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
             ->setMethods(['getEvent', 'getCustomer', 'getName', 'getEmail', 'getOrder', 'getCustomerEmail'])
             ->getMock();
-    
-        $this->identifyCustomerEvent = $this->getMockBuilder(IdentifyCustomer::class)
+
+        $identifyCustomerEvent = $this->getMockBuilder(IdentifyCustomerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['callJs'])
             ->getMock();
-        
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
             ->setMethods(['isEnabled', 'logError'])
             ->getMock();
-    
+
         $this->sessionEvents = $this->getMockBuilder(SessionEvents::class)
             ->disableOriginalConstructor()
             ->setMethods(['addSessionEvent'])
             ->getMock();
-        
+
+        $this->identifyCustomerFactory = $this->getMockBuilder(IdentifyCustomerFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->identifyCustomerFactory->method('create')
+                                      ->will($this->returnValue($identifyCustomerEvent));
+
         $this->identifyCustomerObserver = new IdentifyCustomer(
             $this->dataHelper,
-            $this->sessionEvents
+            $this->sessionEvents,
+            $this->identifyCustomerFactory
         );
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
             ObserverInterface::class,
             new IdentifyCustomer(
                 $this->dataHelper,
-                $this->sessionEvents
+                $this->sessionEvents,
+                $this->identifyCustomerFactory
             )
         );
     }
-    
+
     public function testExecute()
     {
-        $email = 'test@email.com';
-    
         $this->observer->expects($this->any())->method('getEvent')
             ->will($this->returnSelf());
-        $this->observer->expects($this->at(0))->method('getName')
-            ->will($this->returnValue('customer_login'));
-        $this->observer->expects($this->at(1))->method('getName')
-            ->will($this->returnValue('customer_account_edited'));
-        $this->observer->expects($this->at(2))->method('getName')
-            ->will($this->returnValue('sales_order_save_after'));
-    
+        $this->observer->expects($this->exactly(3))->method('getName')->willReturnOnConsecutiveCalls(
+            ['customer_login'],
+            ['customer_account_edited'],
+            ['sales_order_save_after']
+        );
+
         $this->dataHelper->expects($this->any())->method('isEnabled')
             ->with($this->isType('int'))
             ->will($this->returnValue(true));
-        
+
+        $this->identifyCustomerObserver->execute($this->observer);
+        $this->identifyCustomerObserver->execute($this->observer);
         $this->identifyCustomerObserver->execute($this->observer);
     }
 }

--- a/Test/Unit/Observer/ProductTest.php
+++ b/Test/Unit/Observer/ProductTest.php
@@ -4,7 +4,7 @@ namespace Metrilo\Analytics\Test\Unit\Helper;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Sales\Model\Product as ProductModel;
+use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Metrilo\Analytics\Api\Client;
 use Metrilo\Analytics\Helper\Data;
@@ -13,113 +13,85 @@ use Metrilo\Analytics\Helper\ProductSerializer;
 use Metrilo\Analytics\Helper\ProductOptions;
 use Metrilo\Analytics\Model\ProductData;
 use Metrilo\Analytics\Observer\Product;
+use PHPUnit\Framework\TestCase;
 
-class ProductTest extends \PHPUnit\Framework\TestCase
+class ProductTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Metrilo\Analytics\Api\Client
-     */
-    private $client;
-    
-    /**
-     * @var \Magento\Sales\Model\Product
-     */
-    private $productModel;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ApiClient
-     */
-    private $apiClientHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductSerializer
-     */
-    private $productSerializer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\ProductOptions
-     */
-    private $productOptionsHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\ProductData
-     */
-    private $productData;
-    
-    /**
-     * @var \Magento\Catalog\Model\ResourceModel\Product\Collection
-     */
-    private $productCollection;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\ProductObserver
-     */
-    private $productObserver;
-    
+    private Observer $observer;
+
+    private Client $client;
+
+    private ProductModel $productModel;
+
+    private Data $dataHelper;
+
+    private ApiClient $apiClientHelper;
+
+    private ProductSerializer $productSerializer;
+
+    private ProductOptions $productOptionsHelper;
+
+    private ProductData $productData;
+
+    private Collection $productCollection;
+
+    private Product $productObserver;
+
     public function setUp(): void
     {
         $this->observer = $this->getMockBuilder(Observer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEvent', 'getProduct'])
-            ->getMock();
-        
+                               ->disableOriginalConstructor()
+                               ->setMethods(['getEvent', 'getProduct'])
+                               ->getMock();
+
         $this->client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['product'])
-            ->getMock();
-        
-        $this->productModel = $this->getMockBuilder(OrderModel::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getStoreId', 'getStoreIds', 'getId', 'getTypeId'])
-            ->getMock();
-        
+                             ->disableOriginalConstructor()
+                             ->setMethods(['product'])
+                             ->getMock();
+
+        $this->productModel = $this->getMockBuilder(ProductModel::class)
+                                   ->disableOriginalConstructor()
+                                   ->setMethods(['getStoreId', 'getStoreIds', 'getId', 'getTypeId'])
+                                   ->getMock();
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isEnabled', 'logError', 'getStoreIdsPerProject'])
-            ->getMock();
-        
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['isEnabled', 'logError', 'getStoreIdsPerProject'])
+                                 ->getMock();
+
         $this->apiClientHelper = $this->getMockBuilder(ApiClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getClient'])
-            ->getMock();
-        
+                                      ->disableOriginalConstructor()
+                                      ->setMethods(['getClient'])
+                                      ->getMock();
+
         $this->productSerializer = $this->getMockBuilder(ProductSerializer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize'])
-            ->getMock();
-        
+                                        ->disableOriginalConstructor()
+                                        ->setMethods(['serialize'])
+                                        ->getMock();
+
         $this->productOptionsHelper = $this->getMockBuilder(ProductOptions::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentIds', 'getTypeId'])
-            ->getMock();
-        
+                                           ->disableOriginalConstructor()
+                                           ->setMethods(['getParentIds', 'getTypeId'])
+                                           ->getMock();
+
         $this->productData = $this->getMockBuilder(ProductData::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getProductWithRequestPath'])
-            ->getMock();
-        
+                                  ->disableOriginalConstructor()
+                                  ->setMethods(['getProductWithRequestPath'])
+                                  ->getMock();
+
         $this->productCollection = $this->getMockBuilder(Collection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        
+                                        ->disableOriginalConstructor()
+                                        ->getMock();
+
         $this->productObserver = new Product(
             $this->dataHelper,
             $this->apiClientHelper,
             $this->productSerializer,
-            $this->productData
+            $this->productData,
+            $this->productOptionsHelper
         );
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
@@ -128,61 +100,61 @@ class ProductTest extends \PHPUnit\Framework\TestCase
                 $this->dataHelper,
                 $this->apiClientHelper,
                 $this->productSerializer,
-                $this->productData
+                $this->productData,
+                $this->productOptionsHelper
             )
         );
     }
-    
+
     public function testExecute()
     {
-        $storeId     = 1;
-        $storeIds    = [1,2,3];
-        $productId   = 2;
+        $storeId = 1;
+        $storeIds = [1, 2, 3];
+        $productId = 2;
         $productType = 'configurable';
-        
+
         $this->observer->expects($this->any())->method('getEvent')
-            ->will($this->returnSelf());
+                       ->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getProduct')
-            ->will($this->returnValue($this->productModel));
-        
+                       ->will($this->returnValue($this->productModel));
+
         $this->productModel->expects($this->any())->method('getStoreId')
-            ->will($this->returnValue($storeId));
+                           ->will($this->returnValue($storeId));
         $this->productModel->expects($this->any())->method('getStoreIds')
-            ->will($this->returnValue($storeIds));
+                           ->will($this->returnValue($storeIds));
         $this->productModel->expects($this->any())->method('getId')
-            ->will($this->returnValue($productId));
+                           ->will($this->returnValue($productId));
         $this->productModel->expects($this->any())->method('getTypeId')
-            ->will($this->returnValue($productType));
-        
+                           ->will($this->returnValue($productType));
+
         $this->dataHelper->expects($this->any())->method('isEnabled')
-            ->with($this->isType('int'))
-            ->will($this->returnValue(true));
+                         ->with($this->isType('int'))
+                         ->will($this->returnValue(true));
         $this->dataHelper->expects($this->any())->method('logError')
-            ->with($this->isType('object'));
+                         ->with($this->isType('object'));
         $this->dataHelper->expects($this->any())->method('getStoreIdsPerProject')
-            ->with($this->isType('array'))
-            ->will($this->returnValue($storeIds));
-        
+                         ->with($this->isType('array'))
+                         ->will($this->returnValue($storeIds));
+
         $this->apiClientHelper->expects($this->any())->method('getClient')
-            ->with($this->equalTo($storeId))
-            ->will($this->returnValue($this->client));
-        
+                              ->with($this->equalTo($storeId))
+                              ->will($this->returnValue($this->client));
+
         $this->client->expects($this->any())->method('product')
-            ->with($this->isInstanceOf(ProductSerializer::class));
-        
+                     ->with($this->isInstanceOf(ProductSerializer::class));
+
         $this->productOptionsHelper->expects($this->any())->method('getParentIds')
-            ->with($this->equalTo($productId), $this->equalTo($productType))
-            ->will($this->returnValue([]));
-        
+                                   ->with($this->equalTo($productId), $this->equalTo($productType))
+                                   ->will($this->returnValue([]));
+
         $this->productSerializer->expects($this->any())->method('serialize')
-            ->with($this->isInstanceOf(ProductSerializer::class))
-            ->will($this->returnValue([]));
-        $this->productSerializer->productOptions = $this->productOptionsHelper;
-        
+                                ->with($this->isInstanceOf(ProductSerializer::class))
+                                ->will($this->returnValue([]));
+
         $this->productData->expects($this->any())->method('getProductWithRequestPath')
-            ->with($this->isType('int'), $this->equalTo($storeId))
-            ->will($this->returnValue($this->productCollection));
-        
+                          ->with($this->isType('int'), $this->equalTo($storeId))
+                          ->will($this->returnValue($this->productCollection));
+
         $this->productObserver->execute($this->observer);
     }
 }

--- a/Test/Unit/Observer/RemoveFromCartTest.php
+++ b/Test/Unit/Observer/RemoveFromCartTest.php
@@ -2,109 +2,110 @@
 
 namespace Metrilo\Analytics\Test\Unit\Helper;
 
+use Metrilo\Analytics\Model\Events\RemoveFromCartFactory;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\Error\Error;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Metrilo\Analytics\Helper\Data;
 use Metrilo\Analytics\Model\Events\RemoveFromCart as RemoveFromCartEvent;
 use Metrilo\Analytics\Helper\SessionEvents;
 use Metrilo\Analytics\Observer\RemoveFromCart;
+use PHPUnit\Framework\TestCase;
 
-class RemoveFromCartTest extends \PHPUnit\Framework\TestCase
+class RemoveFromCartTest extends TestCase
 {
-    /**
-     * @var \Magento\Framework\Event\Observer
-     */
-    private $observer;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\Data
-     */
-    private $dataHelper;
-    
-    /**
-     * @var \Metrilo\Analytics\Model\Events\RemoveFromCart
-     */
-    private $removeFromCartEvent;
-    
-    /**
-     * @var \Metrilo\Analytics\Helper\SessionEvents
-     */
-    private $sessionEvents;
-    
-    /**
-     * @var \Metrilo\Analytics\Observer\RemoveFromCart
-     */
-    private $removeFromCartObserver;
-    
-    private $storeId   = 1;
-    private $productId = 2;
-    
+
+    private Observer $observer;
+
+    private Data $dataHelper;
+
+    private RemoveFromCartEvent $removeFromCartEvent;
+
+    private SessionEvents $sessionEvents;
+
+    private RemoveFromCartFactory $removeFromCartEventFactory;
+
+    private RemoveFromCart $removeFromCartObserver;
+
+    private $storeId = 1;
+
     public function setUp(): void
     {
         $this->observer = $this->getMockBuilder(Observer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEvent', 'getQuoteItem', 'getStoreId'])
-            ->getMock();
-    
+                               ->disableOriginalConstructor()
+                               ->setMethods(['getEvent', 'getQuoteItem', 'getStoreId'])
+                               ->getMock();
+
         $this->observer->expects($this->any())->method('getEvent')->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getQuoteItem')->will($this->returnSelf());
         $this->observer->expects($this->any())->method('getStoreId')->will($this->returnValue($this->storeId));
-        
+
         $this->dataHelper = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isEnabled', 'logError'])
-            ->getMock();
-    
+                                 ->disableOriginalConstructor()
+                                 ->setMethods(['isEnabled', 'logError'])
+                                 ->getMock();
+
         $this->removeFromCartEvent = $this->getMockBuilder(RemoveFromCartEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['callJs'])
-            ->getMock();
-        
+                                          ->disableOriginalConstructor()
+                                          ->setMethods(['callJs'])
+                                          ->getMock();
+
+        $this->removeFromCartEventFactory = $this->getMockBuilder(RemoveFromCartFactory::class)
+                                                 ->disableOriginalConstructor()
+                                                 ->getMock();
+        $this->removeFromCartEventFactory
+            ->method('create')
+            ->will($this->returnValue($this->removeFromCartEvent));
+
         $this->sessionEvents = $this->getMockBuilder(SessionEvents::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addSessionEvent'])
-            ->getMock();
-    
-        $this->removeFromCartObserver = new RemoveFromCart($this->dataHelper, $this->sessionEvents);
+                                    ->disableOriginalConstructor()
+                                    ->setMethods(['addSessionEvent'])
+                                    ->getMock();
+
+        $this->removeFromCartObserver = new RemoveFromCart(
+            $this->dataHelper,
+            $this->sessionEvents,
+            $this->removeFromCartEventFactory
+        );
     }
-    
+
     public function testImplementsTheObserverInterface()
     {
         $this->assertInstanceOf(
             ObserverInterface::class,
-            new RemoveFromCart($this->dataHelper, $this->sessionEvents)
+            new RemoveFromCart($this->dataHelper, $this->sessionEvents, $this->removeFromCartEventFactory)
         );
     }
-    
+
     public function testExecute()
     {
         $this->dataHelper->expects($this->any())->method('isEnabled')
-            ->with($this->isType('int'))
-            ->will($this->returnValue(true));
-        
+                         ->with($this->isType('int'))
+                         ->will($this->returnValue(true));
+
         $this->removeFromCartEvent->expects($this->any())->method('callJs')
-            ->will($this->returnValue("window.metrilo.removeFromCart('', );"));
-        
+                                  ->will($this->returnValue("window.metrilo.removeFromCart('', );"));
+
         $this->sessionEvents->expects($this->any())->method('addSessionEvent')
-            ->with($this->equalTo($this->removeFromCartEvent->callJs()));
-    
+                            ->with($this->equalTo($this->removeFromCartEvent->callJs()));
+
         $this->removeFromCartObserver->execute($this->observer);
     }
-    
+
     public function testException()
     {
         $this->dataHelper->expects($this->any())->method('isEnabled')
-            ->with($this->isType('string')) // simulation for exception, type should be int
-            ->will($this->returnValue(true));
-    
+                         ->with($this->isType('string')) // simulation for exception, type should be int
+                         ->will($this->returnValue(true));
+
         $this->dataHelper->expects($this->any())->method('logError')
-            ->with($this->isType('object'))
-            ->will($this->returnCallback(function ($error) {
-                $this->assertInstanceOf(ExpectationFailedException::class, $error);
-            }));
-        
+                         ->with($this->isType('object'))
+                         ->will(
+                             $this->returnCallback(function ($error) {
+                                 $this->assertInstanceOf(ExpectationFailedException::class, $error);
+                             })
+                         );
+
         $this->removeFromCartObserver->execute($this->observer);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,39 @@
 {
-  "name": "metrilo/analytics-magento2-extension",
-  "description": "Metrilo Analytics module for magento 2",
-  "require": {
-    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0"
-  },
-  "type": "magento2-module",
-  "version": "2.0.5",
-  "license": [
-    "OSL-3.0",
-    "AFL-3.0"
-  ],
-  "autoload": {
-    "files": [
-      "registration.php"
+    "name": "metrilo/analytics-magento2-extension",
+    "description": "Metrilo Analytics module for magento 2",
+    "require": {
+        "php": ">=7.4.0",
+        "ext-curl": "*",
+        "magento/framework": "*",
+        "magento/module-backend": "*",
+        "magento/module-config": "*",
+        "magento/module-customer": "*",
+        "magento/module-newsletter": "*",
+        "magento/module-sales": "*",
+        "magento/module-catalog": "*",
+        "magento/module-store": "*",
+        "psr/log": "*",
+        "magento/module-bundle": "*",
+        "magento/module-configurable-product": "*",
+        "magento/module-grouped-product": "*",
+        "magento/module-ui": "*",
+        "magento/module-offline-payments": "*",
+        "magento/module-paypal": "*",
+        "magento/module-quote": "*",
+        "laminas/laminas-uri": "*"
+    },
+    "type": "magento2-module",
+    "version": "2.1.0",
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
     ],
-    "psr-4": {
-      "Metrilo\\Analytics\\": ""
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Metrilo\\Analytics\\": ""
+        }
     }
-  }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -30,12 +30,14 @@
                 </field>
                 <field id="api_key" sortOrder="20" type="text" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
                     <depends><field id="enable">1</field></depends>
-                    <label>API Token</label>
+                    <label>API key</label>
+                    <validate>required-entry</validate>
                     <backend_model>Metrilo\Analytics\Model\Trimmed</backend_model>
                 </field>
                 <field id="api_secret" sortOrder="30" type="text" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
                     <depends><field id="enable">1</field></depends>
                     <label>API Secret</label>
+                    <validate>required-entry</validate>
                     <backend_model>Metrilo\Analytics\Model\Trimmed</backend_model>
                 </field>
                 <field id="api_endpoint" sortOrder="40" type="text" translate="label" showInDefault="0" showInWebsite="0" showInStore="0">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,4 +19,46 @@
             <argument name="catalogSearchEvent" xsi:type="object">Metrilo\Analytics\Model\Events\CatalogSearch\Proxy</argument>
         </arguments>
     </type>
+
+    <virtualType name="MetriloAnalyticsLogHandler" type="Magento\Framework\Logger\Handler\Base">
+        <arguments>
+            <argument name="fileName" xsi:type="string">/var/log/metrilo.log</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="Metrilo\Analytics\Logger" type="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">MetriloAnalyticsLogHandler</item>
+                <item name="debug" xsi:type="object">MetriloAnalyticsLogHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="MetriloAnalyticsApiLogHandler" type="Magento\Framework\Logger\Handler\Base">
+        <arguments>
+            <argument name="fileName" xsi:type="string">/var/log/MetriloApiValidationErrors.log</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="Metrilo\Analytics\Api\Logger" type="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">MetriloAnalyticsApiLogHandler</item>
+                <item name="debug" xsi:type="object">MetriloAnalyticsApiLogHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Metrilo\Analytics\Api\Validator">
+        <arguments>
+            <argument name="log" xsi:type="object">Metrilo\Analytics\Api\Logger</argument>
+        </arguments>
+    </type>
+
+    <type name="Metrilo\Analytics\Helper\Data">
+        <arguments>
+            <argument name="logger" xsi:type="object">Metrilo\Analytics\Logger</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -6,11 +6,4 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Customer\Block\SectionConfig">
-        <arguments>
-            <argument name="clientSideSections" xsi:type="array">
-                <item name="metrilo-private-data" xsi:type="string">metrilo-private-data</item>
-            </argument>
-        </arguments>
-    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Metrilo_Analytics" schema_version="1.0.0" setup_version="2.0.5" />
+    <module name="Metrilo_Analytics">
+        <sequence>
+            <module name="Magento_Customer"/>
+            <module name="Magento_Sales"/>
+            <module name="Magento_Newsletter"/>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Backend"/>
+            <module name="Magento_Quote"/>
+            <module name="Magento_OfflinePayments"/>
+            <module name="Magento_ConfigurableProduct"/>
+            <module name="Magento_Bundle"/>
+            <module name="Magento_GroupedProduct"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_Ui"/>
+            <module name="Magento_Config"/>
+        </sequence>
+    </module>
 </config>

--- a/view/adminhtml/templates/system/config/button/import.phtml
+++ b/view/adminhtml/templates/system/config/button/import.phtml
@@ -1,6 +1,7 @@
 <?php
 /**
  * @var $block \Metrilo\Analytics\Block\System\Config\Button\Import
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php if ($block->buttonEnabled()): ?>
@@ -8,8 +9,8 @@
         $storeId = $block->getStoreId();
     ?>
     <div class="pp-buttons-container">
-        <button id="<?php echo $block->getHtmlId() ?>" onclick="return false;">
-            <span><?php echo __('Import'); ?></span>
+        <button id="<?= $block->getHtmlId() ?>" onclick="return false;">
+            <span><?= $escaper->escapeHtml(__('Import')) ?></span>
         </button>
     </div>
     <script>
@@ -17,18 +18,16 @@
         'jquery',
         'metriloImport'
     ], function($, metrilo) {
-        $("#<?php echo $block->getHtmlId() ?>").import({
-            storeId: <?php echo $storeId; ?>,
-            customersChunks: <?php echo $block->getCustomerChunks(); ?>,
-            categoriesChunks: <?php echo $block->getCategoryChunks(); ?>,
-            productsChunks: <?php echo $block->getProductChunks(); ?>,
-            ordersChunks: <?php echo $block->getOrderChunks(); ?>,
-            submitUrl: '<?php echo $block->getAjaxUrl(); ?>',
+        $("#<?= $escaper->escapeJs($block->getHtmlId()) ?>").import({
+            storeId: <?= $escaper->escapeJs($storeId); ?>,
+            customersChunks: <?= $escaper->escapeJs($block->getCustomerChunks()) ?>,
+            categoriesChunks: <?= $escaper->escapeJs($block->getCategoryChunks()) ?>,
+            productsChunks: <?= $escaper->escapeJs($block->getProductChunks()) ?>,
+            ordersChunks: <?= $escaper->escapeJs($block->getOrderChunks()) ?>,
+            submitUrl: '<?= $escaper->escapeUrl($block->getAjaxUrl()) ?>',
             messageSelector: '#metrilo_import_status'
         });
     });
     </script>
     <div id="metrilo_import_status"></div>
-    <?php return; ?>
 <?php endif; ?>
-

--- a/view/frontend/templates/page/analytics.phtml
+++ b/view/frontend/templates/page/analytics.phtml
@@ -1,14 +1,17 @@
 <?php
 /**
- * @see Metrilo\Analytics\Block\Analytics
+ * @var \Metrilo\Analytics\Block\Analytics $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 
-$url    = $block->getLibraryUrl();
+$url = $block->getLibraryUrl();
 $events = $block->getEvents();
 ?>
-<script type="text/javascript">
-    require(['<?php echo $url; ?>'], function(){
-        <?php foreach($events as $event) { echo $event; } ?>
+<script>
+    require(['<?= $escaper->escapeUrl($url) ?>'], function(){
+        <?php foreach ($events as $event): ?>
+            <?= /* @noEscape */ $event ?>
+        <?php endforeach; ?>
     });
 </script>
 <script type="text/x-magento-init">


### PR DESCRIPTION
- Apply fix for 294 PHPStan errors.
- Fix compatibility with PHP8.2.
- Resolve obsolete object creation via 'new' and replace to factory.
- Replace custom logger creation with Magento 2 approach.
- Apply changes according to PHPCS Magento2 static tests errors.
- Fix broken unit tests.
- Apply changes according to PHPMD violations.
- Refactor DeletedProductSerializer.php to resolve PHPMD violations in Unit tests.
- Add missed dependencies in composer.json and fix structure in etc/module.xml.
- Fix logged errors during config save.
- Rename config field according to the instruction on Metrilo.com.
- Fix broken events in private data.